### PR TITLE
Fix CMAKE Extension Settings Not Showing In Bottom Toolbar

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -71,7 +71,8 @@
                     "/usr/local/include/gtest/**"
                 ],
                 // CMAKE extension settings.
-                "cmake.configureOnOpen": false,
+                "cmake.configureOnOpen": true,
+                "cmake.options.statusBarVisibility": "visible",
                 // Format Files extension settings.
                 "formatFiles.excludedFolders": [
                     "node_modules",


### PR DESCRIPTION
The CMAKE extension recently had an update that defaults to hiding the toolkit and config settings. Reset the visibility of those options to show up in the bottom toolbar. Also set the extension to ask to select a toolkit during the first container startup.