### PR TITLE
Switch to C++17 Standard for Compatibility with Other Libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 cmake_minimum_required(VERSION 3.24.3)
 
 ## C++ Version
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## Project Name and Software Version Number

--- a/src/RoveComm/RoveCommManifest.h
+++ b/src/RoveComm/RoveCommManifest.h
@@ -7,7 +7,7 @@
  *
  * @file RoveCommManifest.h
  * @author Missouri S&T - Mars Rover Design Team
- * @date 2024-03-04
+ * @date 2024-03-05
  *
  * @copyright Copyright Mars Rover Design Team 2024 - All Rights Reserved
  ******************************************************************************/
@@ -25,7 +25,7 @@ namespace manifest
      * @brief Enumeration of Data Types to be used in RoveComm
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     enum DataTypes
     {
@@ -44,7 +44,7 @@ namespace manifest
      * @brief IP Address Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     struct AddressEntry
     {
@@ -60,7 +60,7 @@ namespace manifest
      * @brief Manifest Entry Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     struct ManifestEntry
     {
@@ -74,34 +74,34 @@ namespace manifest
      * @brief BMS Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace BMS
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 2, 100);
+        const AddressEntry IP_ADDRESS{192, 168, 2, 100};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"ESTOP", ManifestEntry(1000, 1, DataTypes::UINT8_T)},
-            {"SUICIDE", ManifestEntry(1001, 1, DataTypes::UINT8_T)},
-            {"REBOOT", ManifestEntry(1002, 1, DataTypes::UINT8_T)},
+            {"ESTOP", ManifestEntry{1000, 1, DataTypes::UINT8_T}},
+            {"SUICIDE", ManifestEntry{1001, 1, DataTypes::UINT8_T}},
+            {"REBOOT", ManifestEntry{1002, 1, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"PACKCURRENT", ManifestEntry(1100, 1, DataTypes::FLOAT_T)},
-            {"PACKVOLTAGE", ManifestEntry(1101, 1, DataTypes::FLOAT_T)},
-            {"CELLVOLTAGE", ManifestEntry(1102, 8, DataTypes::FLOAT_T)},
-            {"PACKTEMP", ManifestEntry(1103, 1, DataTypes::FLOAT_T)},
+            {"PACKCURRENT", ManifestEntry{1100, 1, DataTypes::FLOAT_T}},
+            {"PACKVOLTAGE", ManifestEntry{1101, 1, DataTypes::FLOAT_T}},
+            {"CELLVOLTAGE", ManifestEntry{1102, 8, DataTypes::FLOAT_T}},
+            {"PACKTEMP", ManifestEntry{1103, 1, DataTypes::FLOAT_T}},
         };
 
         // Error
         const std::map<std::string, ManifestEntry> ERROR = {
-            {"OVERCURRENT", ManifestEntry(1200, 1, DataTypes::UINT8_T)},
-            {"CELLUNDERVOLTAGE", ManifestEntry(1201, 1, DataTypes::UINT8_T)},
-            {"CELLCRITICAL", ManifestEntry(1202, 1, DataTypes::UINT8_T)},
-            {"PACKOVERHEAT", ManifestEntry(1203, 1, DataTypes::UINT8_T)},
+            {"OVERCURRENT", ManifestEntry{1200, 1, DataTypes::UINT8_T}},
+            {"CELLUNDERVOLTAGE", ManifestEntry{1201, 1, DataTypes::UINT8_T}},
+            {"CELLCRITICAL", ManifestEntry{1202, 1, DataTypes::UINT8_T}},
+            {"PACKOVERHEAT", ManifestEntry{1203, 1, DataTypes::UINT8_T}},
         };
     }    // namespace BMS
 
@@ -109,29 +109,29 @@ namespace manifest
      * @brief Power Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace Power
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 2, 101);
+        const AddressEntry IP_ADDRESS{192, 168, 2, 101};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"ENABLEBUS", ManifestEntry(2000, 1, DataTypes::UINT16_T)},
-            {"DISABLEBUS", ManifestEntry(2001, 1, DataTypes::UINT16_T)},
-            {"SETBUS", ManifestEntry(2002, 1, DataTypes::UINT16_T)},
+            {"ENABLEBUS", ManifestEntry{2000, 1, DataTypes::UINT16_T}},
+            {"DISABLEBUS", ManifestEntry{2001, 1, DataTypes::UINT16_T}},
+            {"SETBUS", ManifestEntry{2002, 1, DataTypes::UINT16_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"BUSSTATUS", ManifestEntry(2100, 1, DataTypes::UINT16_T)},
-            {"BUSCURRENT", ManifestEntry(2101, 18, DataTypes::FLOAT_T)},
+            {"BUSSTATUS", ManifestEntry{2100, 1, DataTypes::UINT16_T}},
+            {"BUSCURRENT", ManifestEntry{2101, 18, DataTypes::FLOAT_T}},
         };
 
         // Error
         const std::map<std::string, ManifestEntry> ERROR = {
-            {"BUSOVERCURRENT", ManifestEntry(2200, 1, DataTypes::UINT32_T)},
+            {"BUSOVERCURRENT", ManifestEntry{2200, 1, DataTypes::UINT32_T}},
         };
     }    // namespace Power
 
@@ -139,33 +139,33 @@ namespace manifest
      * @brief Core Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace Core
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 2, 110);
+        const AddressEntry IP_ADDRESS{192, 168, 2, 110};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"DRIVELEFTRIGHT", ManifestEntry(3000, 2, DataTypes::FLOAT_T)},
-            {"DRIVEINDIVIDUAL", ManifestEntry(3001, 6, DataTypes::FLOAT_T)},
-            {"WATCHDOGOVERRIDE", ManifestEntry(3002, 1, DataTypes::UINT8_T)},
-            {"LEFTDRIVEGIMBALINCREMENT", ManifestEntry(3003, 1, DataTypes::INT16_T)},
-            {"RIGHTDRIVEGIMBALINCREMENT", ManifestEntry(3004, 1, DataTypes::INT16_T)},
-            {"LEFTMAINGIMBALINCREMENT", ManifestEntry(3005, 2, DataTypes::INT16_T)},
-            {"RIGHTMAINGIMBALINCREMENT", ManifestEntry(3006, 2, DataTypes::INT16_T)},
-            {"BACKDRIVEGIMBALINCREMENT", ManifestEntry(3007, 1, DataTypes::INT16_T)},
-            {"LEDRGB", ManifestEntry(3008, 3, DataTypes::UINT8_T)},
-            {"LEDPATTERNS", ManifestEntry(3009, 1, DataTypes::UINT8_T)},
-            {"STATEDISPLAY", ManifestEntry(3010, 1, DataTypes::UINT8_T)},
-            {"BRIGHTNESS", ManifestEntry(3011, 1, DataTypes::UINT8_T)},
-            {"SETWATCHDOGMODE", ManifestEntry(3012, 1, DataTypes::UINT8_T)},
+            {"DRIVELEFTRIGHT", ManifestEntry{3000, 2, DataTypes::FLOAT_T}},
+            {"DRIVEINDIVIDUAL", ManifestEntry{3001, 6, DataTypes::FLOAT_T}},
+            {"WATCHDOGOVERRIDE", ManifestEntry{3002, 1, DataTypes::UINT8_T}},
+            {"LEFTDRIVEGIMBALINCREMENT", ManifestEntry{3003, 1, DataTypes::INT16_T}},
+            {"RIGHTDRIVEGIMBALINCREMENT", ManifestEntry{3004, 1, DataTypes::INT16_T}},
+            {"LEFTMAINGIMBALINCREMENT", ManifestEntry{3005, 2, DataTypes::INT16_T}},
+            {"RIGHTMAINGIMBALINCREMENT", ManifestEntry{3006, 2, DataTypes::INT16_T}},
+            {"BACKDRIVEGIMBALINCREMENT", ManifestEntry{3007, 1, DataTypes::INT16_T}},
+            {"LEDRGB", ManifestEntry{3008, 3, DataTypes::UINT8_T}},
+            {"LEDPATTERNS", ManifestEntry{3009, 1, DataTypes::UINT8_T}},
+            {"STATEDISPLAY", ManifestEntry{3010, 1, DataTypes::UINT8_T}},
+            {"BRIGHTNESS", ManifestEntry{3011, 1, DataTypes::UINT8_T}},
+            {"SETWATCHDOGMODE", ManifestEntry{3012, 1, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"DRIVESPEEDS", ManifestEntry(3100, 6, DataTypes::FLOAT_T)},
+            {"DRIVESPEEDS", ManifestEntry{3100, 6, DataTypes::FLOAT_T}},
         };
 
         // Error
@@ -196,28 +196,28 @@ namespace manifest
      * @brief Nav Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace Nav
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 2, 104);
+        const AddressEntry IP_ADDRESS{192, 168, 2, 104};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {};
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"GPSLATLONALT", ManifestEntry(6100, 3, DataTypes::DOUBLE_T)},
-            {"IMUDATA", ManifestEntry(6101, 3, DataTypes::FLOAT_T)},
-            {"COMPASSDATA", ManifestEntry(6102, 1, DataTypes::FLOAT_T)},
-            {"SATELLITECOUNTDATA", ManifestEntry(6103, 1, DataTypes::UINT8_T)},
-            {"ACCELEROMETERDATA", ManifestEntry(6104, 3, DataTypes::FLOAT_T)},
-            {"ACCURACYDATA", ManifestEntry(6105, 3, DataTypes::FLOAT_T)},
+            {"GPSLATLONALT", ManifestEntry{6100, 3, DataTypes::DOUBLE_T}},
+            {"IMUDATA", ManifestEntry{6101, 3, DataTypes::FLOAT_T}},
+            {"COMPASSDATA", ManifestEntry{6102, 1, DataTypes::FLOAT_T}},
+            {"SATELLITECOUNTDATA", ManifestEntry{6103, 1, DataTypes::UINT8_T}},
+            {"ACCELEROMETERDATA", ManifestEntry{6104, 3, DataTypes::FLOAT_T}},
+            {"ACCURACYDATA", ManifestEntry{6105, 3, DataTypes::FLOAT_T}},
         };
 
         // Error
         const std::map<std::string, ManifestEntry> ERROR = {
-            {"GPSLOCKERROR", ManifestEntry(6200, 1, DataTypes::UINT8_T)},
+            {"GPSLOCKERROR", ManifestEntry{6200, 1, DataTypes::UINT8_T}},
         };
     }    // namespace Nav
 
@@ -225,29 +225,29 @@ namespace manifest
      * @brief SignalStack Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace SignalStack
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 3, 101);
+        const AddressEntry IP_ADDRESS{192, 168, 3, 101};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"OPENLOOP", ManifestEntry(7000, 1, DataTypes::INT16_T)},
-            {"SETANGLETARGET", ManifestEntry(7001, 1, DataTypes::FLOAT_T)},
-            {"SETGPSTARGET", ManifestEntry(7002, 4, DataTypes::DOUBLE_T)},
-            {"WATCHDOGOVERRIDE", ManifestEntry(7003, 1, DataTypes::UINT8_T)},
+            {"OPENLOOP", ManifestEntry{7000, 1, DataTypes::INT16_T}},
+            {"SETANGLETARGET", ManifestEntry{7001, 1, DataTypes::FLOAT_T}},
+            {"SETGPSTARGET", ManifestEntry{7002, 4, DataTypes::DOUBLE_T}},
+            {"WATCHDOGOVERRIDE", ManifestEntry{7003, 1, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"COMPASSANGLE", ManifestEntry(7100, 1, DataTypes::FLOAT_T)},
+            {"COMPASSANGLE", ManifestEntry{7100, 1, DataTypes::FLOAT_T}},
         };
 
         // Error
         const std::map<std::string, ManifestEntry> ERROR = {
-            {"WATCHDOGSTATUS", ManifestEntry(7200, 1, DataTypes::UINT8_T)},
+            {"WATCHDOGSTATUS", ManifestEntry{7200, 1, DataTypes::UINT8_T}},
         };
     }    // namespace SignalStack
 
@@ -255,41 +255,41 @@ namespace manifest
      * @brief Arm Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace Arm
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 2, 107);
+        const AddressEntry IP_ADDRESS{192, 168, 2, 107};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"OPENLOOP", ManifestEntry(8000, 7, DataTypes::INT16_T)},
-            {"SETPOSITION", ManifestEntry(8001, 6, DataTypes::FLOAT_T)},
-            {"INCREMENTPOSITION", ManifestEntry(8002, 6, DataTypes::FLOAT_T)},
-            {"SETIK", ManifestEntry(8003, 5, DataTypes::FLOAT_T)},
-            {"INCREMENTIK_ROVERRELATIVE", ManifestEntry(8004, 5, DataTypes::FLOAT_T)},
-            {"INCREMENTIK_WRISTRELATIVE", ManifestEntry(8005, 5, DataTypes::FLOAT_T)},
-            {"LASER", ManifestEntry(8006, 1, DataTypes::UINT8_T)},
-            {"SOLENOID", ManifestEntry(8007, 1, DataTypes::UINT8_T)},
-            {"GRIPPER", ManifestEntry(8008, 1, DataTypes::INT16_T)},
-            {"WATCHDOGOVERRIDE", ManifestEntry(8009, 1, DataTypes::UINT8_T)},
-            {"LIMITSWITCHOVERRIDE", ManifestEntry(8010, 1, DataTypes::UINT8_T)},
-            {"CALIBRATEENCODER", ManifestEntry(8011, 1, DataTypes::UINT8_T)},
-            {"SELECTGRIPPER", ManifestEntry(8012, 1, DataTypes::UINT8_T)},
-            {"CAMERATILT", ManifestEntry(8013, 1, DataTypes::UINT8_T)},
+            {"OPENLOOP", ManifestEntry{8000, 7, DataTypes::INT16_T}},
+            {"SETPOSITION", ManifestEntry{8001, 6, DataTypes::FLOAT_T}},
+            {"INCREMENTPOSITION", ManifestEntry{8002, 6, DataTypes::FLOAT_T}},
+            {"SETIK", ManifestEntry{8003, 5, DataTypes::FLOAT_T}},
+            {"INCREMENTIK_ROVERRELATIVE", ManifestEntry{8004, 5, DataTypes::FLOAT_T}},
+            {"INCREMENTIK_WRISTRELATIVE", ManifestEntry{8005, 5, DataTypes::FLOAT_T}},
+            {"LASER", ManifestEntry{8006, 1, DataTypes::UINT8_T}},
+            {"SOLENOID", ManifestEntry{8007, 1, DataTypes::UINT8_T}},
+            {"GRIPPER", ManifestEntry{8008, 1, DataTypes::INT16_T}},
+            {"WATCHDOGOVERRIDE", ManifestEntry{8009, 1, DataTypes::UINT8_T}},
+            {"LIMITSWITCHOVERRIDE", ManifestEntry{8010, 1, DataTypes::UINT8_T}},
+            {"CALIBRATEENCODER", ManifestEntry{8011, 1, DataTypes::UINT8_T}},
+            {"SELECTGRIPPER", ManifestEntry{8012, 1, DataTypes::UINT8_T}},
+            {"CAMERATILT", ManifestEntry{8013, 1, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"POSITIONS", ManifestEntry(8100, 7, DataTypes::FLOAT_T)},
-            {"COORDINATES", ManifestEntry(8101, 5, DataTypes::FLOAT_T)},
-            {"LIMITSWITCHTRIGGERED", ManifestEntry(8102, 1, DataTypes::UINT8_T)},
+            {"POSITIONS", ManifestEntry{8100, 7, DataTypes::FLOAT_T}},
+            {"COORDINATES", ManifestEntry{8101, 5, DataTypes::FLOAT_T}},
+            {"LIMITSWITCHTRIGGERED", ManifestEntry{8102, 1, DataTypes::UINT8_T}},
         };
 
         // Error
         const std::map<std::string, ManifestEntry> ERROR = {
-            {"WATCHDOGSTATUS", ManifestEntry(8200, 1, DataTypes::UINT8_T)},
+            {"WATCHDOGSTATUS", ManifestEntry{8200, 1, DataTypes::UINT8_T}},
         };
     }    // namespace Arm
 
@@ -297,39 +297,39 @@ namespace manifest
      * @brief ScienceActuation Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace ScienceActuation
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 2, 108);
+        const AddressEntry IP_ADDRESS{192, 168, 2, 108};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"SCOOPAXIS_OPENLOOP", ManifestEntry(9000, 1, DataTypes::INT16_T)},
-            {"SENSORAXIS_OPENLOOP", ManifestEntry(9001, 1, DataTypes::INT16_T)},
-            {"SCOOPAXIS_SETPOSITION", ManifestEntry(9002, 1, DataTypes::FLOAT_T)},
-            {"SENSORAXIS_SETPOSITION", ManifestEntry(9003, 1, DataTypes::FLOAT_T)},
-            {"SCOOPAXIS_INCREMENTPOSITION", ManifestEntry(9004, 1, DataTypes::FLOAT_T)},
-            {"SENSORAXIS_INCREMENTPOSITION", ManifestEntry(9005, 1, DataTypes::FLOAT_T)},
-            {"LIMITSWITCHOVERRIDE", ManifestEntry(9006, 1, DataTypes::UINT8_T)},
-            {"AUGER", ManifestEntry(9007, 1, DataTypes::INT16_T)},
-            {"MICROSCOPE", ManifestEntry(9008, 1, DataTypes::UINT8_T)},
-            {"PROBOSCIS", ManifestEntry(9009, 1, DataTypes::INT16_T)},
-            {"WATCHDOGOVERRIDE", ManifestEntry(9010, 1, DataTypes::UINT8_T)},
-            {"CALIBRATEENCODER", ManifestEntry(9011, 1, DataTypes::UINT8_T)},
+            {"SCOOPAXIS_OPENLOOP", ManifestEntry{9000, 1, DataTypes::INT16_T}},
+            {"SENSORAXIS_OPENLOOP", ManifestEntry{9001, 1, DataTypes::INT16_T}},
+            {"SCOOPAXIS_SETPOSITION", ManifestEntry{9002, 1, DataTypes::FLOAT_T}},
+            {"SENSORAXIS_SETPOSITION", ManifestEntry{9003, 1, DataTypes::FLOAT_T}},
+            {"SCOOPAXIS_INCREMENTPOSITION", ManifestEntry{9004, 1, DataTypes::FLOAT_T}},
+            {"SENSORAXIS_INCREMENTPOSITION", ManifestEntry{9005, 1, DataTypes::FLOAT_T}},
+            {"LIMITSWITCHOVERRIDE", ManifestEntry{9006, 1, DataTypes::UINT8_T}},
+            {"AUGER", ManifestEntry{9007, 1, DataTypes::INT16_T}},
+            {"MICROSCOPE", ManifestEntry{9008, 1, DataTypes::UINT8_T}},
+            {"PROBOSCIS", ManifestEntry{9009, 1, DataTypes::INT16_T}},
+            {"WATCHDOGOVERRIDE", ManifestEntry{9010, 1, DataTypes::UINT8_T}},
+            {"CALIBRATEENCODER", ManifestEntry{9011, 1, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"POSITIONS", ManifestEntry(9100, 3, DataTypes::FLOAT_T)},
-            {"LIMITSWITCHTRIGGERED", ManifestEntry(9101, 1, DataTypes::UINT8_T)},
-            {"ENVIRONMENTALDATA", ManifestEntry(9102, 2, DataTypes::FLOAT_T)},
+            {"POSITIONS", ManifestEntry{9100, 3, DataTypes::FLOAT_T}},
+            {"LIMITSWITCHTRIGGERED", ManifestEntry{9101, 1, DataTypes::UINT8_T}},
+            {"ENVIRONMENTALDATA", ManifestEntry{9102, 2, DataTypes::FLOAT_T}},
         };
 
         // Error
         const std::map<std::string, ManifestEntry> ERROR = {
-            {"WATCHDOGSTATUS", ManifestEntry(9200, 1, DataTypes::UINT8_T)},
+            {"WATCHDOGSTATUS", ManifestEntry{9200, 1, DataTypes::UINT8_T}},
         };
     }    // namespace ScienceActuation
 
@@ -337,29 +337,29 @@ namespace manifest
      * @brief Autonomy Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace Autonomy
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 3, 100);
+        const AddressEntry IP_ADDRESS{192, 168, 3, 100};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"STARTAUTONOMY", ManifestEntry(11000, 1, DataTypes::UINT8_T)},
-            {"DISABLEAUTONOMY", ManifestEntry(11001, 1, DataTypes::UINT8_T)},
-            {"ADDPOSITIONLEG", ManifestEntry(11002, 2, DataTypes::DOUBLE_T)},
-            {"ADDMARKERLEG", ManifestEntry(11003, 2, DataTypes::DOUBLE_T)},
-            {"ADDGATELEG", ManifestEntry(11004, 2, DataTypes::DOUBLE_T)},
-            {"CLEARWAYPOINTS", ManifestEntry(11005, 1, DataTypes::UINT8_T)},
-            {"SETMAXSPEED", ManifestEntry(11006, 1, DataTypes::UINT16_T)},
+            {"STARTAUTONOMY", ManifestEntry{11000, 1, DataTypes::UINT8_T}},
+            {"DISABLEAUTONOMY", ManifestEntry{11001, 1, DataTypes::UINT8_T}},
+            {"ADDPOSITIONLEG", ManifestEntry{11002, 2, DataTypes::DOUBLE_T}},
+            {"ADDMARKERLEG", ManifestEntry{11003, 2, DataTypes::DOUBLE_T}},
+            {"ADDGATELEG", ManifestEntry{11004, 2, DataTypes::DOUBLE_T}},
+            {"CLEARWAYPOINTS", ManifestEntry{11005, 1, DataTypes::UINT8_T}},
+            {"SETMAXSPEED", ManifestEntry{11006, 1, DataTypes::UINT16_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"CURRENTSTATE", ManifestEntry(11100, 1, DataTypes::UINT8_T)},
-            {"REACHEDMARKER", ManifestEntry(11101, 1, DataTypes::UINT8_T)},
-            {"CURRENTLOG", ManifestEntry(11102, 255, DataTypes::CHAR)},
+            {"CURRENTSTATE", ManifestEntry{11100, 1, DataTypes::UINT8_T}},
+            {"REACHEDMARKER", ManifestEntry{11101, 1, DataTypes::UINT8_T}},
+            {"CURRENTLOG", ManifestEntry{11102, 255, DataTypes::CHAR}},
         };
 
         // Error
@@ -384,27 +384,27 @@ namespace manifest
      * @brief Camera1 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace Camera1
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 4, 100);
+        const AddressEntry IP_ADDRESS{192, 168, 4, 100};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"CHANGECAMERAS", ManifestEntry(12000, 2, DataTypes::UINT8_T)},
+            {"CHANGECAMERAS", ManifestEntry{12000, 2, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"AVAILABLECAMERAS", ManifestEntry(12100, 1, DataTypes::UINT8_T)},
-            {"STREAMINGCAMERAS", ManifestEntry(12101, 4, DataTypes::UINT8_T)},
+            {"AVAILABLECAMERAS", ManifestEntry{12100, 1, DataTypes::UINT8_T}},
+            {"STREAMINGCAMERAS", ManifestEntry{12101, 4, DataTypes::UINT8_T}},
         };
 
         // Error
         const std::map<std::string, ManifestEntry> ERROR = {
-            {"CAMERAUNAVAILABLE", ManifestEntry(12200, 1, DataTypes::UINT8_T)},
+            {"CAMERAUNAVAILABLE", ManifestEntry{12200, 1, DataTypes::UINT8_T}},
         };
     }    // namespace Camera1
 
@@ -412,12 +412,12 @@ namespace manifest
      * @brief Camera2 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace Camera2
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 4, 101);
+        const AddressEntry IP_ADDRESS{192, 168, 4, 101};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {};
@@ -431,26 +431,26 @@ namespace manifest
      * @brief RamanSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace RamanSpectrometer
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 3, 102);
+        const AddressEntry IP_ADDRESS{192, 168, 3, 102};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"ENABLELEDS", ManifestEntry(13000, 1, DataTypes::UINT8_T)},
-            {"REQUESTREADING", ManifestEntry(13001, 1, DataTypes::UINT8_T)},
+            {"ENABLELEDS", ManifestEntry{13000, 1, DataTypes::UINT8_T}},
+            {"REQUESTREADING", ManifestEntry{13001, 1, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"CCDREADING_PART1", ManifestEntry(13100, 500, DataTypes::UINT16_T)},
-            {"CCDREADING_PART2", ManifestEntry(13101, 500, DataTypes::UINT16_T)},
-            {"CCDREADING_PART3", ManifestEntry(13102, 500, DataTypes::UINT16_T)},
-            {"CCDREADING_PART4", ManifestEntry(13103, 500, DataTypes::UINT16_T)},
-            {"CCDREADING_PART5", ManifestEntry(13104, 48, DataTypes::UINT16_T)},
+            {"CCDREADING_PART1", ManifestEntry{13100, 500, DataTypes::UINT16_T}},
+            {"CCDREADING_PART2", ManifestEntry{13101, 500, DataTypes::UINT16_T}},
+            {"CCDREADING_PART3", ManifestEntry{13102, 500, DataTypes::UINT16_T}},
+            {"CCDREADING_PART4", ManifestEntry{13103, 500, DataTypes::UINT16_T}},
+            {"CCDREADING_PART5", ManifestEntry{13104, 48, DataTypes::UINT16_T}},
         };
 
         // Error
@@ -461,22 +461,22 @@ namespace manifest
      * @brief Fluorometer Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace Fluorometer
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 3, 103);
+        const AddressEntry IP_ADDRESS{192, 168, 3, 103};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"ENABLELEDS", ManifestEntry(14000, 1, DataTypes::UINT8_T)},
-            {"REQUESTREADING", ManifestEntry(14001, 1, DataTypes::UINT8_T)},
+            {"ENABLELEDS", ManifestEntry{14000, 1, DataTypes::UINT8_T}},
+            {"REQUESTREADING", ManifestEntry{14001, 1, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"READING", ManifestEntry(14100, 288, DataTypes::UINT8_T)},
+            {"READING", ManifestEntry{14100, 288, DataTypes::UINT8_T}},
         };
 
         // Error
@@ -487,12 +487,12 @@ namespace manifest
      * @brief IRSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace IRSpectrometer
     {
         // IP Address
-        const AddressEntry IP_ADDRESS(192, 168, 3, 104);
+        const AddressEntry IP_ADDRESS{192, 168, 3, 104};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {};
@@ -506,7 +506,7 @@ namespace manifest
      * @brief RoveComm General Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace General
     {
@@ -521,7 +521,7 @@ namespace manifest
      * @brief RoveComm System Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace System
     {
@@ -537,7 +537,7 @@ namespace manifest
      * @brief RoveComm Helper Functions
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-04
+     * @date 2024-03-05
      ******************************************************************************/
     namespace Helpers
     {

--- a/src/RoveComm/RoveCommTCP.cpp
+++ b/src/RoveComm/RoveCommTCP.cpp
@@ -480,6 +480,8 @@ namespace rovecomm
     template ssize_t RoveCommTCP::SendTCPPacket<uint8_t>(const RoveCommPacket<uint8_t>&, const char*, int);
     template void RoveCommTCP::AddTCPCallback<uint8_t>(std::function<void(const RoveCommPacket<uint8_t>&)>, const uint16_t&);
     template void RoveCommTCP::RemoveTCPCallback<uint8_t>(std::function<void(const RoveCommPacket<uint8_t>&)>);
+    template void RoveCommTCP::ProcessPacket<uint8_t>(const RoveCommData& stData,
+                                                      const std::vector<std::tuple<std::function<void(const rovecomm::RoveCommPacket<uint8_t>&)>, uint16_t>>& vCallbacks);
 
     template ssize_t RoveCommTCP::SendTCPPacket<int8_t>(const RoveCommPacket<int8_t>&, const char*, int);
     template void RoveCommTCP::AddTCPCallback<int8_t>(std::function<void(const RoveCommPacket<int8_t>&)>, const uint16_t&);

--- a/tests/Unit/src/tcp.cc
+++ b/tests/Unit/src/tcp.cc
@@ -178,7 +178,7 @@ TEST(RoveCommTCP, CallbackInvoked)
             rovecomm::RoveCommData stData = rovecomm::PackPacket(stPacket);
 
             // Process the received packet (simulate callback invocation)
-            pRoveCommTCP_Node.CallProcessPacket<uint8_t>(stData, rovecomm::tcp::vUInt8Callbacks);
+            pRoveCommTCP_Node.CallProcessPacket(stData, rovecomm::tcp::vUInt8Callbacks);
 
             // Check if the callback was invoked
             EXPECT_TRUE(bCallbackInvoked);

--- a/tools/RoveComm/parser.py
+++ b/tools/RoveComm/parser.py
@@ -39,7 +39,7 @@ def insert_address(board):
         ip_octs = ip.split(".")
 
         this.header_file.write(f"{generate_indent(2)}// IP Address\n")
-        this.header_file.write(f"{generate_indent(2)}const AddressEntry IP_ADDRESS({ip_octs[0]}, {ip_octs[1]}, {ip_octs[2]}, {ip_octs[3]});\n")
+        this.header_file.write(f"{generate_indent(2)}const AddressEntry IP_ADDRESS{{{ip_octs[0]}, {ip_octs[1]}, {ip_octs[2]}, {ip_octs[3]}}};\n")
 
         this.header_file.write("\n")
 
@@ -73,7 +73,7 @@ def insert_packets(board, type):
             dataType = type_to_struct[dataType]
 
 
-            this.header_file.write(f"{generate_indent(3)}{{\"{message.upper()}\", ManifestEntry({dataId}, {dataCount}, {dataType})}},\n")
+            this.header_file.write(f"{generate_indent(3)}{{\"{message.upper()}\", ManifestEntry{{{dataId}, {dataCount}, {dataType}}}}},\n")
 
         this.header_file.write(f"{generate_indent(2)}}};\n")
 


### PR DESCRIPTION
Switched to C++17:
- Updated parser.py for manifest generation.
- Added templated implementation to make Unit tests work.