### PR TITLE
Non-blocking Sockets and Resource Management

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -85,7 +85,7 @@ SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 InsertNewlineAtEOF: true
-Standard: c++14
+Standard: c++17
 TabWidth: 4
 UseTab: Never
 DisableFormat: false

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -60,7 +60,7 @@
                 // C/C++ extension settings.
                 "C_Cpp.formatting": "clangFormat",
                 "C_Cpp.default.compilerPath": "/usr/bin/g++-10",
-                "C_Cpp.default.cppStandard": "c++20",
+                "C_Cpp.default.cppStandard": "c++17",
                 "C_Cpp.default.includePath": [
                     "/usr/local/include/quill/",
                     "/usr/local/include/quill/**",

--- a/src/RoveComm/RoveCommConsts.h
+++ b/src/RoveComm/RoveCommConsts.h
@@ -25,5 +25,8 @@ namespace rovecomm
 #define ROVECOMM_PACKET_MAX_DATA_COUNT        65535
 #define ROVECOMM_PACKET_HEADER_SIZE           6
 #define ROVECOMM_VERSION                      3
+
+    // Server constants.
+    const int ROVECOMM_THREAD_MAX_IPS = 120;
 }    // namespace rovecomm
 #endif    // ROVECOMM_CONSTS_H

--- a/src/RoveComm/RoveCommTCP.cpp
+++ b/src/RoveComm/RoveCommTCP.cpp
@@ -150,6 +150,12 @@ namespace rovecomm
 
         // Send the data
         ssize_t siBytesSent = send(nClientSocket, &stData, sizeof(stData), 0);
+        // Check if any bytes were sent.
+        if (siBytesSent == -1)
+        {
+            // Handle and print error message.
+            perror("Failed to send data to TCP client socket");
+        }
 
         // Close the client socket
         close(nClientSocket);

--- a/src/RoveComm/RoveCommTCP.cpp
+++ b/src/RoveComm/RoveCommTCP.cpp
@@ -34,6 +34,34 @@
 namespace rovecomm
 {
     /******************************************************************************
+     * @brief Construct a new RoveCommTCP::RoveCommTCP object.
+     *
+     *
+     * @author clayjay3 (claytonraycowen@gmail.com)
+     * @date 2024-03-07
+     ******************************************************************************/
+    RoveCommTCP::RoveCommTCP()
+    {
+        // Initialize member variables.
+        m_nTCPSocket              = -1;
+        m_nCurrentTCPClientSocket = -1;
+
+        // Set an IPS cap in the backend RoveComm thread.
+        this->SetMainThreadIPSLimit(rovecomm::ROVECOMM_THREAD_MAX_IPS);
+    }
+
+    /******************************************************************************
+     * @brief Destroy the RoveCommTCP::RoveCommTCP object.
+     *
+     * @author Eli Byrd (edbgkk@mst.edu)
+     * @date 2024-02-07
+     ******************************************************************************/
+    RoveCommTCP::~RoveCommTCP()
+    {
+        CloseTCPSocket();
+    }
+
+    /******************************************************************************
      * @brief Initializes a TCP socket and binds it to the specified IP address and
      *        port. And then starts the threaded continuous code in AutonomyThread.
      *
@@ -74,7 +102,7 @@ namespace rovecomm
         m_saTCPServerAddr.sin_port        = htons(nPort);
 
         // Bind the socket to the server address
-        if (bind(m_nTCPSocket, (struct sockaddr*) &m_saTCPServerAddr, sizeof(m_saTCPServerAddr)) == -1)
+        if (bind(m_nTCPSocket.load(), (struct sockaddr*) &m_saTCPServerAddr, sizeof(m_saTCPServerAddr)) == -1)
         {
             perror("Failed to bind TCP socket");
             close(m_nTCPSocket);
@@ -182,6 +210,9 @@ namespace rovecomm
     template<typename T>
     void RoveCommTCP::AddTCPCallback(std::function<void(const RoveCommPacket<T>&)> fnCallback, const uint16_t& unCondition)
     {
+        // Acquire a write lock to protect the callback vectors.
+        std::unique_lock<std::shared_mutex> lkCallbackLock(m_muCallbackMutex);
+
         // Add the callback function to the vector of TCP callbacks for the specified data type
         if constexpr (std::is_same_v<T, uint8_t>)
         {
@@ -247,6 +278,9 @@ namespace rovecomm
     template<typename T>
     void RoveCommTCP::RemoveTCPCallback(std::function<void(const RoveCommPacket<T>&)> fnCallback)
     {
+        // Acquire a write lock to protect the callback vectors.
+        std::unique_lock<std::shared_mutex> lkCallbackLock(m_muCallbackMutex);
+
         // Remove the callback function from the appropriate vector based on the data type T
         if constexpr (std::is_same_v<T, uint8_t>)
         {
@@ -348,7 +382,11 @@ namespace rovecomm
     void RoveCommTCP::ProcessPacket(const RoveCommData& stData,
                                     const std::vector<std::tuple<std::function<void(const rovecomm::RoveCommPacket<T>&)>, uint16_t>>& vCallbacks)
     {
+        // Create instance variables.
         RoveCommPacket<T> stPacket = UnpackData<T>(stData);
+
+        // Acquire a read lock to protect the callback vectors.
+        std::shared_lock<std::shared_mutex> lkCallbackLock(m_muCallbackMutex);
 
         // Invoke registered callbacks
         for (const std::tuple<std::function<void(const rovecomm::RoveCommPacket<T>&)>, uint16_t>& tpCallbackInfo : vCallbacks)
@@ -380,68 +418,52 @@ namespace rovecomm
      ******************************************************************************/
     void RoveCommTCP::ReceiveTCPPacketAndCallback()
     {
-        // Accept a client connection
-        struct sockaddr_in saClientAddr;
-        socklen_t sklClientAddrLen = sizeof(saClientAddr);
-        int nClientSocket          = accept(m_nTCPSocket, (struct sockaddr*) &saClientAddr, &sklClientAddrLen);
-        if (errno == EAGAIN || errno == EWOULDBLOCK)
+        if (m_nCurrentTCPClientSocket == -1)
         {
-            // Still waiting for connection return without error.
-            return;
+            // Accept a client connection
+            struct sockaddr_in m_saClientAddr;
+            socklen_t sklClientAddrLen = sizeof(m_saClientAddr);
+            m_nCurrentTCPClientSocket  = accept(m_nTCPSocket, (struct sockaddr*) &m_saClientAddr, &sklClientAddrLen);
         }
-        else if (nClientSocket == -1)
+        else
         {
-            perror("Failed to accept client connection");
-            return;
-        }
+            // Receive data from the client
+            RoveCommData stData;
+            ssize_t siBytesReceived = recv(m_nCurrentTCPClientSocket, &stData, sizeof(stData), 0);
 
-        // Receive data from the client
-        RoveCommData stData;
-        ssize_t siBytesReceived = recv(nClientSocket, &stData, sizeof(stData), 0);
-        if (errno == EAGAIN || errno == EWOULDBLOCK)
-        {
-            // Still waiting for data or connection return without error.
-            return;
-        }
-        else if (siBytesReceived < 0)
-        {
-            perror("Error receiving data from client");
-            close(nClientSocket);
-            return;
-        }
-        else if (siBytesReceived == 0)
-        {
-            // Connection closed by client
-            close(nClientSocket);
-            return;
-        }
-
-        // Process the received packet and invoke the appropriate callback
-        if (siBytesReceived == sizeof(RoveCommData))
-        {
-            // Extract the data id from the received data
-            uint16_t unDataId = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);
-
-            // Determine the data type from the received data
-            manifest::DataTypes eDataType = manifest::Helpers::GetDataTypeFromId(unDataId);
-
-            // Convert RoveCommData to appropriate RoveCommPacket based on data type
-            switch (eDataType)
+            // Process the received packet and invoke the appropriate callback
+            if (siBytesReceived == sizeof(RoveCommData))
             {
-                case manifest::DataTypes::UINT8_T: ProcessPacket<uint8_t>(stData, tcp::vUInt8Callbacks); break;
-                case manifest::DataTypes::INT8_T: ProcessPacket<int8_t>(stData, tcp::vInt8Callbacks); break;
-                case manifest::DataTypes::UINT16_T: ProcessPacket<uint16_t>(stData, tcp::vUInt16Callbacks); break;
-                case manifest::DataTypes::INT16_T: ProcessPacket<int16_t>(stData, tcp::vInt16Callbacks); break;
-                case manifest::DataTypes::UINT32_T: ProcessPacket<uint32_t>(stData, tcp::vUInt32Callbacks); break;
-                case manifest::DataTypes::INT32_T: ProcessPacket<int32_t>(stData, tcp::vInt32Callbacks); break;
-                case manifest::DataTypes::FLOAT_T: ProcessPacket<float>(stData, tcp::vFloatCallbacks); break;
-                case manifest::DataTypes::DOUBLE_T: ProcessPacket<double>(stData, tcp::vDoubleCallbacks); break;
-                case manifest::DataTypes::CHAR: ProcessPacket<char>(stData, tcp::vCharCallbacks); break;
+                // Extract the data id from the received data
+                uint16_t unDataId = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);
+
+                // Determine the data type from the received data
+                manifest::DataTypes eDataType = manifest::Helpers::GetDataTypeFromId(unDataId);
+
+                // Convert RoveCommData to appropriate RoveCommPacket based on data type
+                switch (eDataType)
+                {
+                    case manifest::DataTypes::UINT8_T: ProcessPacket<uint8_t>(stData, tcp::vUInt8Callbacks); break;
+                    case manifest::DataTypes::INT8_T: ProcessPacket<int8_t>(stData, tcp::vInt8Callbacks); break;
+                    case manifest::DataTypes::UINT16_T: ProcessPacket<uint16_t>(stData, tcp::vUInt16Callbacks); break;
+                    case manifest::DataTypes::INT16_T: ProcessPacket<int16_t>(stData, tcp::vInt16Callbacks); break;
+                    case manifest::DataTypes::UINT32_T: ProcessPacket<uint32_t>(stData, tcp::vUInt32Callbacks); break;
+                    case manifest::DataTypes::INT32_T: ProcessPacket<int32_t>(stData, tcp::vInt32Callbacks); break;
+                    case manifest::DataTypes::FLOAT_T: ProcessPacket<float>(stData, tcp::vFloatCallbacks); break;
+                    case manifest::DataTypes::DOUBLE_T: ProcessPacket<double>(stData, tcp::vDoubleCallbacks); break;
+                    case manifest::DataTypes::CHAR: ProcessPacket<char>(stData, tcp::vCharCallbacks); break;
+                }
+
+                // Close the client socket
+                close(m_nCurrentTCPClientSocket);
+                m_nCurrentTCPClientSocket == -1;
+            }
+            // Still waiting for data or connection return without error.
+            else if (siBytesReceived == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))
+            {
+                return;
             }
         }
-
-        // Close the client socket
-        close(nClientSocket);
     }
 
     /******************************************************************************
@@ -490,17 +512,6 @@ namespace rovecomm
             // Close the TCP socket
             close(m_nTCPSocket);
         }
-    }
-
-    /******************************************************************************
-     * @brief Destroy the RoveCommTCP::RoveCommTCP object.
-     *
-     * @author Eli Byrd (edbgkk@mst.edu)
-     * @date 2024-02-07
-     ******************************************************************************/
-    RoveCommTCP::~RoveCommTCP()
-    {
-        CloseTCPSocket();
     }
 
     // Explicitly define template function types for TCP class

--- a/src/RoveComm/RoveCommTCP.cpp
+++ b/src/RoveComm/RoveCommTCP.cpp
@@ -501,6 +501,8 @@ namespace rovecomm
     template ssize_t RoveCommTCP::SendTCPPacket<uint8_t>(const RoveCommPacket<uint8_t>&, const char*, int);
     template void RoveCommTCP::AddTCPCallback<uint8_t>(std::function<void(const RoveCommPacket<uint8_t>&)>, const uint16_t&);
     template void RoveCommTCP::RemoveTCPCallback<uint8_t>(std::function<void(const RoveCommPacket<uint8_t>&)>);
+    template void RoveCommTCP::ProcessPacket<uint8_t>(const RoveCommData& stData,
+                                                      const std::vector<std::tuple<std::function<void(const rovecomm::RoveCommPacket<uint8_t>&)>, uint16_t>>& vCallbacks);
 
     template ssize_t RoveCommTCP::SendTCPPacket<int8_t>(const RoveCommPacket<int8_t>&, const char*, int);
     template void RoveCommTCP::AddTCPCallback<int8_t>(std::function<void(const RoveCommPacket<int8_t>&)>, const uint16_t&);

--- a/src/RoveComm/RoveCommTCP.cpp
+++ b/src/RoveComm/RoveCommTCP.cpp
@@ -456,7 +456,7 @@ namespace rovecomm
 
                 // Close the client socket
                 close(m_nCurrentTCPClientSocket);
-                m_nCurrentTCPClientSocket == -1;
+                m_nCurrentTCPClientSocket = -1;
             }
             // Still waiting for data or connection return without error.
             else if (siBytesReceived == -1 && (errno == EAGAIN || errno == EWOULDBLOCK))

--- a/src/RoveComm/RoveCommTCP.h
+++ b/src/RoveComm/RoveCommTCP.h
@@ -93,6 +93,9 @@ namespace rovecomm
             // Deinitialization
             void CloseTCPSocket();
 
+            // Selectively make inherited method public so we can get RoveCommNode FPS.
+            using AutonomyThread::GetIPS;
+
             // NOTE: These functions are for testing purposes only and should not be used in production code!
             template<typename T>
             void CallProcessPacket(const RoveCommData& stData,

--- a/src/RoveComm/RoveCommTCP.h
+++ b/src/RoveComm/RoveCommTCP.h
@@ -21,11 +21,13 @@
 
 /// \cond
 #include <arpa/inet.h>
+#include <atomic>
 #include <csignal>
 #include <cstring>
 #include <functional>
 #include <iostream>
 #include <netinet/in.h>
+#include <shared_mutex>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <vector>
@@ -53,8 +55,11 @@ namespace rovecomm
     {
         private:
             // Private member variables
-            int m_nTCPSocket;
+            std::atomic_int m_nTCPSocket;
             struct sockaddr_in m_saTCPServerAddr;
+            std::atomic_int m_nCurrentTCPClientSocket;
+            struct sockaddr_in m_saClientAddr;
+            std::shared_mutex m_muCallbackMutex;
 
             // Packet processing functions
             template<typename T>
@@ -67,7 +72,9 @@ namespace rovecomm
 
         public:
             // Constructor
-            RoveCommTCP() : m_nTCPSocket(-1) {}
+            RoveCommTCP();
+            // Destructor
+            ~RoveCommTCP();
 
             // Initialization
             bool InitTCPSocket(const char* cIPAddress, int nPort);
@@ -85,9 +92,6 @@ namespace rovecomm
 
             // Deinitialization
             void CloseTCPSocket();
-
-            // Destructor
-            ~RoveCommTCP();
 
             // NOTE: These functions are for testing purposes only and should not be used in production code!
             template<typename T>

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -121,7 +121,11 @@ namespace rovecomm
         {
             saUDPClientAddr.sin_port = htons(stSubscriber.nPort);
             inet_pton(AF_INET, stSubscriber.szIPAddress.c_str(), &saUDPClientAddr.sin_addr);
-            sendto(m_nUDPSocket, &data, sizeof(data), 0, (struct sockaddr*) &saUDPClientAddr, sizeof(saUDPClientAddr));
+            if (sendto(m_nUDPSocket, &data, sizeof(data), 0, (struct sockaddr*) &saUDPClientAddr, sizeof(saUDPClientAddr)) == -1)
+            {
+                // Handle and print error message.
+                perror("Failed to send data to UDP client socket subscriber.");
+            }
         }
 
         // Send the packet to the specified IP address and port

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -15,6 +15,7 @@
 /// \cond
 #include <arpa/inet.h>
 #include <cstring>
+#include <fcntl.h>
 #include <functional>
 #include <iostream>
 #include <netinet/in.h>
@@ -55,6 +56,16 @@ namespace rovecomm
         {
             perror("Failed to create UDP socket");
             return false;
+        }
+        else
+        {
+            // Attempt to set the socket to non-blocking mode.
+            if (fcntl(m_nUDPSocket, F_SETFL, fcntl(m_nUDPSocket, F_GETFL) | O_NONBLOCK) == -1)
+            {
+                // Handle and print error.
+                perror("Failed to set UDP socket to non-blocking mode.");
+                return false;
+            }
         }
 
         // Configure the server address

--- a/src/RoveComm/RoveCommUDP.h
+++ b/src/RoveComm/RoveCommUDP.h
@@ -98,6 +98,9 @@ namespace rovecomm
             // Deinitialization
             void CloseUDPSocket();
 
+            // Selectively make inherited method public so we can get RoveCommNode FPS.
+            using AutonomyThread::GetIPS;
+
             // NOTE: These functions are for testing purposes only and should not be used in production code!
             template<typename T>
             void CallProcessPacket(const RoveCommData& stData,

--- a/src/RoveComm/RoveCommUDP.h
+++ b/src/RoveComm/RoveCommUDP.h
@@ -20,11 +20,13 @@
 
 /// \cond
 #include <arpa/inet.h>
+#include <atomic>
 #include <csignal>
 #include <cstring>
 #include <functional>
 #include <iostream>
 #include <netinet/in.h>
+#include <shared_mutex>
 #include <sys/socket.h>
 #include <unistd.h>
 #include <unordered_set>
@@ -53,9 +55,10 @@ namespace rovecomm
     {
         private:
             // Private member variables
-            int m_nUDPSocket;
+            std::atomic_int m_nUDPSocket;
             struct sockaddr_in m_saUDPServerAddr;
             std::vector<SubscriberInfo> vSubscribers;
+            std::shared_mutex m_muCallbackMutex;
 
             // Packet processing functions
             template<typename T>
@@ -74,7 +77,9 @@ namespace rovecomm
 
         public:
             // Constructor
-            RoveCommUDP() : m_nUDPSocket(-1) {}
+            RoveCommUDP();
+            // Destructor
+            ~RoveCommUDP();
 
             // Initialization
             bool InitUDPSocket(int nPort);
@@ -92,9 +97,6 @@ namespace rovecomm
 
             // Deinitialization
             void CloseUDPSocket();
-
-            // Destructor
-            ~RoveCommUDP();
 
             // NOTE: These functions are for testing purposes only and should not be used in production code!
             template<typename T>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,6 +127,9 @@ int main()
     // Send the packet to the localhost
     pRoveCommUDP_Node.SendUDPPacket<uint8_t>(stPacket, "127.0.0.1", 11000);
 
+    // Wait for packets to be processed.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
     exit(0);
 
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,6 +131,7 @@ int main()
 
     // Send the packet to the localhost
     pRoveCommUDP_Node.SendUDPPacket<uint8_t>(stPacket, "127.0.0.1", 11000);
+    pRoveCommTCP_Node.SendTCPPacket<uint8_t>(stPacket, "127.0.0.1", 12000);
 
     // Wait for packets to be processed.
     std::this_thread::sleep_for(std::chrono::milliseconds(500));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ int main()
     {
         (void) addr;
 
-        std::cout << "Received packet with:" << std::endl;
+        std::cout << "Received UDP packet with:" << std::endl;
         std::cout << "\tData ID: " << packet.unDataId << std::endl;
         std::cout << "\tData Count: " << packet.unDataCount << std::endl;
         std::cout << "\tData Type: " << packet.eDataType << std::endl;
@@ -109,30 +109,33 @@ int main()
     pRoveCommUDP_Node.AddUDPCallback<uint8_t>(UDPCallback, 11000);
     pRoveCommUDP_Node.AddUDPCallback<uint8_t>(UDPCallback, 11000);
     pRoveCommTCP_Node.AddTCPCallback<uint8_t>(TCPCallback, 11000);
+    pRoveCommTCP_Node.AddTCPCallback<uint8_t>(TCPCallback, 11000);
 
     // Create RoveCommPacket
     RoveCommPacket<uint8_t> stPacket;
     stPacket.unDataId    = manifest::Autonomy::COMMANDS.find("STARTAUTONOMY")->second.DATA_ID;
     stPacket.unDataCount = manifest::Autonomy::COMMANDS.find("STARTAUTONOMY")->second.DATA_COUNT;
     stPacket.eDataType   = manifest::Autonomy::COMMANDS.find("STARTAUTONOMY")->second.DATA_TYPE;
-    stPacket.vData.push_back(1);
+    stPacket.vData.push_back(200);
 
     // Send the packet to the localhost
     pRoveCommUDP_Node.SendUDPPacket<uint8_t>(stPacket, "127.0.0.1", 11000);
     pRoveCommTCP_Node.SendTCPPacket<uint8_t>(stPacket, "127.0.0.1", 12000);
 
+    // Wait for packets to be processed.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
     // Remove the callback functions for UINT8_T data type from the UDP and TCP nodes
     pRoveCommUDP_Node.RemoveUDPCallback<uint8_t>(UDPCallback);
+    pRoveCommUDP_Node.AddUDPCallback<uint8_t>(UDPCallback, 11000);
 
     // Send the packet to the localhost
     pRoveCommUDP_Node.SendUDPPacket<uint8_t>(stPacket, "127.0.0.1", 11000);
 
     // Wait for packets to be processed.
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     exit(0);
-
-    return 0;
 }
 
 #endif    // __ROVECOMM_LIBRARY_MODE__


### PR DESCRIPTION
# Main Changes:
- Configured sockets do be non-blocking and reworked some of the socket logic.
- Added atomics and mutexes to fix corrupt or incomplete transmission of data.

## Other Changes:
- Made only GetIPS() from AutonomyThread accessible so that RoveComm thread IPS can be retrieved.
- Added IPS cap to thread. Now limited to 120 IPS.

Resolves #15 