### PR TITLE
Update Manifest and Fix Bugs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "data/RoveComm"]
 	path = data/RoveComm
-	url = https://github.com/MissouriMRDT/RoveComm_Base
+	url = git@github.com:MissouriMRDT/RoveComm_Base.git
     branch = embedded-2024

--- a/src/RoveComm/RoveCommManifest.h
+++ b/src/RoveComm/RoveCommManifest.h
@@ -7,7 +7,7 @@
  *
  * @file RoveCommManifest.h
  * @author Missouri S&T - Mars Rover Design Team
- * @date 2024-03-15
+ * @date 2024-03-16
  *
  * @copyright Copyright Mars Rover Design Team 2024 - All Rights Reserved
  ******************************************************************************/
@@ -25,7 +25,7 @@ namespace manifest
      * @brief Enumeration of Data Types to be used in RoveComm
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     enum DataTypes
     {
@@ -44,7 +44,7 @@ namespace manifest
      * @brief IP Address Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     struct AddressEntry
     {
@@ -60,7 +60,7 @@ namespace manifest
      * @brief Manifest Entry Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     struct ManifestEntry
     {
@@ -74,7 +74,7 @@ namespace manifest
      * @brief BMS Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace BMS
     {
@@ -109,7 +109,7 @@ namespace manifest
      * @brief Power Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace Power
     {
@@ -139,7 +139,7 @@ namespace manifest
      * @brief Core Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace Core
     {
@@ -196,7 +196,7 @@ namespace manifest
      * @brief Nav Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace Nav
     {
@@ -225,7 +225,7 @@ namespace manifest
      * @brief BaseStationNav Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace BaseStationNav
     {
@@ -244,7 +244,7 @@ namespace manifest
      * @brief SignalStack Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace SignalStack
     {
@@ -274,7 +274,7 @@ namespace manifest
      * @brief Arm Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace Arm
     {
@@ -316,7 +316,7 @@ namespace manifest
      * @brief ScienceActuation Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace ScienceActuation
     {
@@ -356,7 +356,7 @@ namespace manifest
      * @brief Autonomy Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace Autonomy
     {
@@ -405,7 +405,7 @@ namespace manifest
      * @brief Camera1 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace Camera1
     {
@@ -433,7 +433,7 @@ namespace manifest
      * @brief Camera2 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace Camera2
     {
@@ -452,7 +452,7 @@ namespace manifest
      * @brief RamanSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace RamanSpectrometer
     {
@@ -482,7 +482,7 @@ namespace manifest
      * @brief Fluorometer Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace Fluorometer
     {
@@ -508,7 +508,7 @@ namespace manifest
      * @brief IRSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace IRSpectrometer
     {
@@ -527,7 +527,7 @@ namespace manifest
      * @brief RoveComm General Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace General
     {
@@ -542,7 +542,7 @@ namespace manifest
      * @brief RoveComm System Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace System
     {
@@ -558,7 +558,7 @@ namespace manifest
      * @brief RoveComm Helper Functions
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-15
+     * @date 2024-03-16
      ******************************************************************************/
     namespace Helpers
     {

--- a/src/RoveComm/RoveCommManifest.h
+++ b/src/RoveComm/RoveCommManifest.h
@@ -7,7 +7,7 @@
  *
  * @file RoveCommManifest.h
  * @author Missouri S&T - Mars Rover Design Team
- * @date 2024-03-14
+ * @date 2024-03-15
  *
  * @copyright Copyright Mars Rover Design Team 2024 - All Rights Reserved
  ******************************************************************************/
@@ -25,7 +25,7 @@ namespace manifest
      * @brief Enumeration of Data Types to be used in RoveComm
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     enum DataTypes
     {
@@ -44,7 +44,7 @@ namespace manifest
      * @brief IP Address Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     struct AddressEntry
     {
@@ -60,7 +60,7 @@ namespace manifest
      * @brief Manifest Entry Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     struct ManifestEntry
     {
@@ -74,7 +74,7 @@ namespace manifest
      * @brief BMS Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace BMS
     {
@@ -109,7 +109,7 @@ namespace manifest
      * @brief Power Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace Power
     {
@@ -139,7 +139,7 @@ namespace manifest
      * @brief Core Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace Core
     {
@@ -196,7 +196,7 @@ namespace manifest
      * @brief Nav Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace Nav
     {
@@ -222,15 +222,34 @@ namespace manifest
     }    // namespace Nav
 
     /******************************************************************************
+     * @brief BaseStationNav Board IP Address, Commands, Telemetry, and Error 
+     *
+     * @author Missouri S&T - Mars Rover Design Team
+     * @date 2024-03-15
+     ******************************************************************************/
+    namespace BaseStationNav
+    {
+        // IP Address
+        const AddressEntry IP_ADDRESS{192, 168, 100, 112};
+
+        // Commands
+        const std::map<std::string, ManifestEntry> COMMANDS = {};
+        // Telemetry
+        const std::map<std::string, ManifestEntry> TELEMETRY = {};
+        // Error
+        const std::map<std::string, ManifestEntry> ERROR = {};
+    }    // namespace BaseStationNav
+
+    /******************************************************************************
      * @brief SignalStack Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace SignalStack
     {
         // IP Address
-        const AddressEntry IP_ADDRESS{192, 168, 3, 101};
+        const AddressEntry IP_ADDRESS{192, 168, 100, 101};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
@@ -255,7 +274,7 @@ namespace manifest
      * @brief Arm Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace Arm
     {
@@ -297,7 +316,7 @@ namespace manifest
      * @brief ScienceActuation Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace ScienceActuation
     {
@@ -337,7 +356,7 @@ namespace manifest
      * @brief Autonomy Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace Autonomy
     {
@@ -350,7 +369,7 @@ namespace manifest
             {"DISABLEAUTONOMY", ManifestEntry{11001, 1, DataTypes::UINT8_T}},
             {"ADDPOSITIONLEG", ManifestEntry{11002, 2, DataTypes::DOUBLE_T}},
             {"ADDMARKERLEG", ManifestEntry{11003, 2, DataTypes::DOUBLE_T}},
-            {"ADDGATELEG", ManifestEntry{11004, 2, DataTypes::DOUBLE_T}},
+            {"ADDOBJECTLEG", ManifestEntry{11004, 2, DataTypes::DOUBLE_T}},
             {"CLEARWAYPOINTS", ManifestEntry{11005, 1, DataTypes::UINT8_T}},
             {"SETMAXSPEED", ManifestEntry{11006, 1, DataTypes::UINT16_T}},
         };
@@ -372,7 +391,9 @@ namespace manifest
             NAVIGATING,
             SEARCHPATTERN,
             APPROACHINGMARKER,
-            APPROACHINGGATE,
+            APPROACHINGOBJECT,
+            VERIFYINGMARKER,
+            VERIFYINGOBJECT,
             AVOIDANCE,
             REVERSING,
             STUCK
@@ -384,7 +405,7 @@ namespace manifest
      * @brief Camera1 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace Camera1
     {
@@ -412,7 +433,7 @@ namespace manifest
      * @brief Camera2 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace Camera2
     {
@@ -431,7 +452,7 @@ namespace manifest
      * @brief RamanSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace RamanSpectrometer
     {
@@ -461,7 +482,7 @@ namespace manifest
      * @brief Fluorometer Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace Fluorometer
     {
@@ -487,7 +508,7 @@ namespace manifest
      * @brief IRSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace IRSpectrometer
     {
@@ -506,7 +527,7 @@ namespace manifest
      * @brief RoveComm General Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace General
     {
@@ -521,7 +542,7 @@ namespace manifest
      * @brief RoveComm System Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace System
     {
@@ -537,7 +558,7 @@ namespace manifest
      * @brief RoveComm Helper Functions
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2024-03-14
+     * @date 2024-03-15
      ******************************************************************************/
     namespace Helpers
     {

--- a/src/RoveComm/RoveCommTCP.cpp
+++ b/src/RoveComm/RoveCommTCP.cpp
@@ -429,10 +429,10 @@ namespace rovecomm
         {
             // Receive data from the client
             RoveCommData stData;
-            ssize_t siBytesReceived = recv(m_nCurrentTCPClientSocket, &stData, sizeof(stData), 0);
+            ssize_t siBytesReceived = recv(m_nCurrentTCPClientSocket, &stData, sizeof(stData), MSG_DONTWAIT);
 
             // Process the received packet and invoke the appropriate callback
-            if (siBytesReceived == sizeof(RoveCommData))
+            if (siBytesReceived != -1)
             {
                 // Extract the data id from the received data
                 uint16_t unDataId = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);

--- a/src/RoveComm/RoveCommTCP.cpp
+++ b/src/RoveComm/RoveCommTCP.cpp
@@ -176,8 +176,10 @@ namespace rovecomm
         // Pack the data
         RoveCommData stData = PackPacket(stPacket);
 
+        // Get size of data not including the data not filled. (the null/zero data in RoveCommData)
+        size_t siDataSize = ROVECOMM_PACKET_HEADER_SIZE + (sizeof(T) * stPacket.unDataCount);
         // Send the data
-        ssize_t siBytesSent = send(nClientSocket, &stData, sizeof(stData), 0);
+        ssize_t siBytesSent = send(nClientSocket, &stData, siDataSize, 0);
         // Check if any bytes were sent.
         if (siBytesSent == -1)
         {

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -157,7 +157,7 @@ namespace rovecomm
         }
 
         // Send the packet to the specified IP address and port
-        if (cIPAddress != "0.0.0.0" && nPort != 0)
+        if (std::strcmp(cIPAddress, "0.0.0.0") && nPort != 0)
         {
             saUDPClientAddr.sin_port = htons(nPort);
             inet_pton(AF_INET, cIPAddress, &saUDPClientAddr.sin_addr);

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -410,9 +410,9 @@ namespace rovecomm
         sockaddr_in saClientAddr;
         socklen_t addrLen          = sizeof(saClientAddr);
 
-        ssize_t siUDPBytesReceived = recvfrom(m_nUDPSocket, &stData, sizeof(stData), 0, (struct sockaddr*) &saClientAddr, &addrLen);
+        ssize_t siUDPBytesReceived = recvfrom(m_nUDPSocket, &stData, sizeof(stData), MSG_DONTWAIT, (struct sockaddr*) &saClientAddr, &addrLen);
 
-        if (siUDPBytesReceived == sizeof(RoveCommData))
+        if (siUDPBytesReceived != -1)
         {
             // Extract the data id from the received data
             uint16_t unDataId = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);

--- a/src/RoveComm/RoveCommUDP.h
+++ b/src/RoveComm/RoveCommUDP.h
@@ -86,7 +86,7 @@ namespace rovecomm
 
             // Data transmission functions
             template<typename T>
-            ssize_t SendUDPPacket(const RoveCommPacket<T>& stData, const char* cIPAddress, int nPort);
+            ssize_t SendUDPPacket(const RoveCommPacket<T>& stPacket, const char* cIPAddress, int nPort);
 
             // Callback management functions
             template<typename T>

--- a/tests/Unit/src/tcp.cc
+++ b/tests/Unit/src/tcp.cc
@@ -100,7 +100,7 @@ TEST(RoveCommTCP, SendTCPPacket)
             ssize_t siBytesSent = pRoveCommTCP_Node.SendTCPPacket<uint8_t>(stPacket, "127.0.0.1", 12001);
 
             // Check if the packet successfully sent
-            EXPECT_EQ(siBytesSent, sizeof(rovecomm::PackPacket<uint8_t>(stPacket)));
+            EXPECT_EQ(siBytesSent, ROVECOMM_PACKET_HEADER_SIZE + (sizeof(uint8_t) * stPacket.unDataCount));
 
             // Close the socket
             pRoveCommTCP_Node.CloseTCPSocket();

--- a/tests/Unit/src/udp.cc
+++ b/tests/Unit/src/udp.cc
@@ -112,7 +112,7 @@ TEST(RoveCommUDP, SendUDPPacket)
                 ssize_t siBytesSent = pRoveCommUDP_Node.SendUDPPacket<uint8_t>(stPacket, "127.0.0.1", 11001);
 
                 // Check if the packet successfully sent
-                EXPECT_EQ(siBytesSent, sizeof(rovecomm::PackPacket<uint8_t>(stPacket)));
+                EXPECT_EQ(siBytesSent, ROVECOMM_PACKET_HEADER_SIZE + (sizeof(uint8_t) * stPacket.unDataCount));
 
                 // Close the socket
                 pRoveCommUDP_Node.CloseUDPSocket();

--- a/tools/RoveComm/parser.py
+++ b/tools/RoveComm/parser.py
@@ -48,7 +48,7 @@ def insert_packets(board, type):
     This inserts all Ids for a given type (Command, Telemetry, Error)
     Currently adds the comments, dataId, dataCount and dataType
     """
-    if (len(this.manifest[board][type]) > 0):
+    if (type in this.manifest[board].keys() and len(this.manifest[board][type]) > 0):
         messages = this.manifest[board][type]
 
         if (type == "Commands"):

--- a/tools/RoveComm/parser.py
+++ b/tools/RoveComm/parser.py
@@ -243,9 +243,7 @@ def find_board_and_data_id(json_file):
         data = json.load(f)
 
     for board_name in data['RovecommManifest'].keys():
-        print(1, board_name)
         for component in data['RovecommManifest'][board_name].keys():
-            print(2, component)
             if 'Commands' in component:
                 for command in data['RovecommManifest'][board_name]['Commands'].values():
                     data_id = command['dataId'] // 1000


### PR DESCRIPTION
Update manifest (RoveComm-Base) for new autonomy commands.
Fix parser bug where it would crash if a board didn't have any command, telemetry, or error keys.
Fix socket bugs to make RoveComm_CPP compatible with other implementation of RoveComm.
Fix Cstring comparison bug.