### PR TITLE
Fixed Float and Double Data Corruption. Use Proper Network Bit Formats

### DIFF
--- a/src/RoveComm/RoveCommPacket.h
+++ b/src/RoveComm/RoveCommPacket.h
@@ -17,9 +17,14 @@
 /// \cond
 #include <cstdint>
 #include <cstring>
+#include <netinet/in.h>
 #include <vector>
 
 /// \endcond
+
+// These are used to convert 64-bit doubles to network bit order and back.
+#define htonll(x) ((1 == htonl(1)) ? (x) : (((uint64_t) htonl((x) & 0xFFFFFFFFUL)) << 32) | htonl((uint32_t) ((x) >> 32)))
+#define ntohll(x) ((1 == ntohl(1)) ? (x) : (((uint64_t) ntohl((x) & 0xFFFFFFFFUL)) << 32) | ntohl((uint32_t) ((x) >> 32)))
 
 /******************************************************************************
  * @brief The RoveComm namespace contains all of the functionality for the

--- a/src/RoveComm/RoveCommTCP.cpp
+++ b/src/RoveComm/RoveCommTCP.cpp
@@ -440,7 +440,8 @@ namespace rovecomm
                 uint16_t unDataId = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);
 
                 // Determine the data type from the received data
-                manifest::DataTypes eDataType = manifest::Helpers::GetDataTypeFromId(unDataId);
+                // manifest::DataTypes eDataType = manifest::Helpers::GetDataTypeFromId(unDataId);
+                manifest::DataTypes eDataType = static_cast<manifest::DataTypes>(stData.unBytes[5]);
 
                 // Convert RoveCommData to appropriate RoveCommPacket based on data type
                 switch (eDataType)

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -420,9 +420,9 @@ namespace rovecomm
         {
             // Extract the data id from the received data
             uint16_t unDataId = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);
-
             // Determine the data type from the received data
-            manifest::DataTypes eDataType = manifest::Helpers::GetDataTypeFromId(unDataId);
+            // manifest::DataTypes eDataType = manifest::Helpers::GetDataTypeFromId(unDataId);
+            manifest::DataTypes eDataType = static_cast<manifest::DataTypes>(stData.unBytes[5]);
 
             // Convert RoveCommData to appropriate RoveCommPacket based on data type
             switch (eDataType)


### PR DESCRIPTION
# Main Changes:
- Use C++ htonl() and ntohl() functions to ensure uniform and consistent sending of byte data across RoveComm network. This ensures that no matter what floating point storage system the host uses the bit data sent across the network will be consistent and readable by other systems.

## Other Changes:
- Instead of using complex helper to get data size of packet, just trust what the incoming packets header says the datasize is.