### PR TITLE
Fix Odd Include Order Bug on Windows

### DIFF
--- a/src/RoveComm/RoveCommPacket.h
+++ b/src/RoveComm/RoveCommPacket.h
@@ -29,8 +29,8 @@ typedef int ssize_t;
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
 #endif
-#include <windows.h>
 #include <winsock2.h>
+#include <windows.h>
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>


### PR DESCRIPTION
For some odd reason, if you include `windows.h` before `winsock2.h`, then the compiler gets confused about symbols and fails to build. These symbols aren't even part of our project either.