### PR TITLE
Rework Send and Receive of RoveComm_CPP to Improve Speed and Lower Latency

### DIFF
--- a/src/RoveComm/RoveCommManifest.h
+++ b/src/RoveComm/RoveCommManifest.h
@@ -7,7 +7,7 @@
  *
  * @file RoveCommManifest.h
  * @author Missouri S&T - Mars Rover Design Team
- * @date 2025-02-18
+ * @date 2025-02-19
  *
  * @copyright Copyright Mars Rover Design Team 2025 - All Rights Reserved
  ******************************************************************************/
@@ -25,7 +25,7 @@ namespace manifest
      * @brief Enumeration of Data Types to be used in RoveComm
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     enum DataTypes
     {
@@ -44,7 +44,7 @@ namespace manifest
      * @brief IP Address Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     struct AddressEntry
     {
@@ -60,7 +60,7 @@ namespace manifest
      * @brief Manifest Entry Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     struct ManifestEntry
     {
@@ -74,7 +74,7 @@ namespace manifest
      * @brief Core Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace Core
     {
@@ -134,7 +134,7 @@ namespace manifest
      * @brief PMS Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace PMS
     {
@@ -174,7 +174,7 @@ namespace manifest
      * @brief Nav Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace Nav
     {
@@ -203,7 +203,7 @@ namespace manifest
      * @brief BaseStationNav Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace BaseStationNav
     {
@@ -222,7 +222,7 @@ namespace manifest
      * @brief SignalStack Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace SignalStack
     {
@@ -252,7 +252,7 @@ namespace manifest
      * @brief Arm Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace Arm
     {
@@ -311,7 +311,7 @@ namespace manifest
      * @brief Auger Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace Auger
     {
@@ -353,7 +353,7 @@ namespace manifest
      * @brief Autonomy Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace Autonomy
     {
@@ -369,6 +369,7 @@ namespace manifest
             {"ADDOBJECTLEG", ManifestEntry{11004, 3, DataTypes::DOUBLE_T}},
             {"ADDOBSTACLE", ManifestEntry{11008, 3, DataTypes::DOUBLE_T}},
             {"CLEARWAYPOINTS", ManifestEntry{11005, 1, DataTypes::UINT8_T}},
+            {"CLEAROBSTACLES", ManifestEntry{11009, 1, DataTypes::UINT8_T}},
             {"SETMAXSPEED", ManifestEntry{11006, 1, DataTypes::FLOAT_T}},
             {"SETLOGGINGLEVELS", ManifestEntry{11007, 3, DataTypes::UINT8_T}},
         };
@@ -418,7 +419,7 @@ namespace manifest
      * @brief Camera1 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace Camera1
     {
@@ -449,7 +450,7 @@ namespace manifest
      * @brief Camera2 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace Camera2
     {
@@ -475,7 +476,7 @@ namespace manifest
      * @brief CameraServer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace CameraServer
     {
@@ -512,7 +513,7 @@ namespace manifest
      * @brief IRSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace IRSpectrometer
     {
@@ -531,7 +532,7 @@ namespace manifest
      * @brief Raman Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace Raman
     {
@@ -570,7 +571,7 @@ namespace manifest
      * @brief RoveSoSimulator Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace RoveSoSimulator
     {
@@ -592,7 +593,7 @@ namespace manifest
      * @brief RoveComm General Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace General
     {
@@ -607,7 +608,7 @@ namespace manifest
      * @brief RoveComm System Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace System
     {
@@ -623,7 +624,7 @@ namespace manifest
      * @brief RoveComm Helper Functions
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-18
+     * @date 2025-02-19
      ******************************************************************************/
     namespace Helpers
     {

--- a/src/RoveComm/RoveCommManifest.h
+++ b/src/RoveComm/RoveCommManifest.h
@@ -7,7 +7,7 @@
  *
  * @file RoveCommManifest.h
  * @author Missouri S&T - Mars Rover Design Team
- * @date 2025-02-19
+ * @date 2025-02-20
  *
  * @copyright Copyright Mars Rover Design Team 2025 - All Rights Reserved
  ******************************************************************************/
@@ -25,7 +25,7 @@ namespace manifest
      * @brief Enumeration of Data Types to be used in RoveComm
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     enum DataTypes
     {
@@ -44,7 +44,7 @@ namespace manifest
      * @brief IP Address Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     struct AddressEntry
     {
@@ -60,7 +60,7 @@ namespace manifest
      * @brief Manifest Entry Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     struct ManifestEntry
     {
@@ -74,7 +74,7 @@ namespace manifest
      * @brief Core Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace Core
     {
@@ -134,7 +134,7 @@ namespace manifest
      * @brief PMS Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace PMS
     {
@@ -174,7 +174,7 @@ namespace manifest
      * @brief Nav Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace Nav
     {
@@ -203,7 +203,7 @@ namespace manifest
      * @brief BaseStationNav Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace BaseStationNav
     {
@@ -222,7 +222,7 @@ namespace manifest
      * @brief SignalStack Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace SignalStack
     {
@@ -252,7 +252,7 @@ namespace manifest
      * @brief Arm Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace Arm
     {
@@ -311,7 +311,7 @@ namespace manifest
      * @brief Auger Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace Auger
     {
@@ -353,7 +353,7 @@ namespace manifest
      * @brief Autonomy Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace Autonomy
     {
@@ -419,7 +419,7 @@ namespace manifest
      * @brief Camera1 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace Camera1
     {
@@ -450,7 +450,7 @@ namespace manifest
      * @brief Camera2 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace Camera2
     {
@@ -476,7 +476,7 @@ namespace manifest
      * @brief CameraServer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace CameraServer
     {
@@ -513,7 +513,7 @@ namespace manifest
      * @brief IRSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace IRSpectrometer
     {
@@ -532,7 +532,7 @@ namespace manifest
      * @brief Raman Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace Raman
     {
@@ -571,7 +571,7 @@ namespace manifest
      * @brief RoveSoSimulator Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace RoveSoSimulator
     {
@@ -593,7 +593,7 @@ namespace manifest
      * @brief RoveComm General Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace General
     {
@@ -608,7 +608,7 @@ namespace manifest
      * @brief RoveComm System Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace System
     {
@@ -624,7 +624,7 @@ namespace manifest
      * @brief RoveComm Helper Functions
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-19
+     * @date 2025-02-20
      ******************************************************************************/
     namespace Helpers
     {

--- a/src/RoveComm/RoveCommManifest.h
+++ b/src/RoveComm/RoveCommManifest.h
@@ -367,11 +367,11 @@ namespace manifest
             {"ADDPOSITIONLEG", ManifestEntry{11002, 2, DataTypes::DOUBLE_T}},
             {"ADDMARKERLEG", ManifestEntry{11003, 4, DataTypes::DOUBLE_T}},
             {"ADDOBJECTLEG", ManifestEntry{11004, 3, DataTypes::DOUBLE_T}},
-            {"ADDOBSTACLE", ManifestEntry{11008, 3, DataTypes::DOUBLE_T}},
             {"CLEARWAYPOINTS", ManifestEntry{11005, 1, DataTypes::UINT8_T}},
-            {"CLEAROBSTACLES", ManifestEntry{11009, 1, DataTypes::UINT8_T}},
             {"SETMAXSPEED", ManifestEntry{11006, 1, DataTypes::FLOAT_T}},
             {"SETLOGGINGLEVELS", ManifestEntry{11007, 3, DataTypes::UINT8_T}},
+            {"ADDOBSTACLE", ManifestEntry{11008, 3, DataTypes::DOUBLE_T}},
+            {"CLEAROBSTACLES", ManifestEntry{11009, 1, DataTypes::UINT8_T}},
         };
 
         // Telemetry

--- a/src/RoveComm/RoveCommManifest.h
+++ b/src/RoveComm/RoveCommManifest.h
@@ -7,7 +7,7 @@
  *
  * @file RoveCommManifest.h
  * @author Missouri S&T - Mars Rover Design Team
- * @date 2025-02-01
+ * @date 2025-02-18
  *
  * @copyright Copyright Mars Rover Design Team 2025 - All Rights Reserved
  ******************************************************************************/
@@ -25,7 +25,7 @@ namespace manifest
      * @brief Enumeration of Data Types to be used in RoveComm
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     enum DataTypes
     {
@@ -44,7 +44,7 @@ namespace manifest
      * @brief IP Address Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     struct AddressEntry
     {
@@ -60,7 +60,7 @@ namespace manifest
      * @brief Manifest Entry Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     struct ManifestEntry
     {
@@ -74,7 +74,7 @@ namespace manifest
      * @brief Core Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace Core
     {
@@ -134,7 +134,7 @@ namespace manifest
      * @brief PMS Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace PMS
     {
@@ -174,7 +174,7 @@ namespace manifest
      * @brief Nav Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace Nav
     {
@@ -203,7 +203,7 @@ namespace manifest
      * @brief BaseStationNav Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace BaseStationNav
     {
@@ -222,7 +222,7 @@ namespace manifest
      * @brief SignalStack Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace SignalStack
     {
@@ -252,7 +252,7 @@ namespace manifest
      * @brief Arm Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace Arm
     {
@@ -279,6 +279,7 @@ namespace manifest
             {"CLOSEDLOOPOVERRIDE", ManifestEntry{8015, 6, DataTypes::UINT8_T}},
             {"CALIBRATEENCODER", ManifestEntry{8016, 2, DataTypes::UINT8_T}},
             {"SOFTLIMITOVERRIDE", ManifestEntry{8017, 10, DataTypes::UINT16_T}},
+            {"ESTOP", ManifestEntry{8018, 1, DataTypes::UINT8_T}},
         };
 
         // Telemetry
@@ -307,39 +308,38 @@ namespace manifest
     }    // namespace Arm
 
     /******************************************************************************
-     * @brief ScienceActuation Board IP Address, Commands, Telemetry, and Error 
+     * @brief Auger Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
-    namespace ScienceActuation
+    namespace Auger
     {
         // IP Address
         const AddressEntry IP_ADDRESS{192, 168, 2, 108};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"SCOOPAXIS_OPENLOOP", ManifestEntry{9000, 1, DataTypes::INT16_T}},
-            {"SENSORAXIS_OPENLOOP", ManifestEntry{9001, 1, DataTypes::INT16_T}},
-            {"SCOOPAXIS_SETPOSITION", ManifestEntry{9002, 1, DataTypes::FLOAT_T}},
-            {"SENSORAXIS_SETPOSITION", ManifestEntry{9003, 1, DataTypes::FLOAT_T}},
-            {"SCOOPAXIS_INCREMENTPOSITION", ManifestEntry{9004, 1, DataTypes::FLOAT_T}},
-            {"SENSORAXIS_INCREMENTPOSITION", ManifestEntry{9005, 1, DataTypes::FLOAT_T}},
-            {"LIMITSWITCHOVERRIDE", ManifestEntry{9006, 1, DataTypes::UINT8_T}},
-            {"AUGER", ManifestEntry{9007, 1, DataTypes::INT16_T}},
-            {"MICROSCOPE", ManifestEntry{9008, 1, DataTypes::UINT8_T}},
-            {"WATCHDOGOVERRIDE", ManifestEntry{9010, 1, DataTypes::UINT8_T}},
-            {"CALIBRATEENCODER", ManifestEntry{9011, 1, DataTypes::UINT8_T}},
-            {"REQUESTHUMIDITY", ManifestEntry{9012, 1, DataTypes::UINT8_T}},
-            {"AUGERGIMBALINCREMENT", ManifestEntry{9013, 2, DataTypes::INT16_T}},
+            {"AUGERAXIS_OPENLOOP", ManifestEntry{9000, 1, DataTypes::INT16_T}},
+            {"AUGERAXIS_SETPOSITION", ManifestEntry{9001, 1, DataTypes::FLOAT_T}},
+            {"AUGERAXIS_INCREMENTPOSITION", ManifestEntry{9002, 1, DataTypes::FLOAT_T}},
+            {"LIMITSWITCHOVERRIDE", ManifestEntry{9003, 1, DataTypes::UINT8_T}},
+            {"CALIBRATEENCODER", ManifestEntry{9004, 1, DataTypes::UINT8_T}},
+            {"AUGER", ManifestEntry{9005, 1, DataTypes::INT16_T}},
+            {"WATCHDOGOVERRIDE", ManifestEntry{9006, 1, DataTypes::UINT8_T}},
+            {"REQUESTTEMPERATURE", ManifestEntry{9007, 1, DataTypes::UINT8_T}},
+            {"REQUESTHUMIDITY", ManifestEntry{9008, 1, DataTypes::UINT8_T}},
+            {"UVLED", ManifestEntry{9009, 1, DataTypes::UINT8_T}},
+            {"AUGERGIMBALINCREMENT", ManifestEntry{9010, 2, DataTypes::INT16_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"POSITIONS", ManifestEntry{9100, 2, DataTypes::FLOAT_T}},
-            {"LIMITSWITCHTRIGGERED", ManifestEntry{9101, 1, DataTypes::UINT8_T}},
-            {"HUMIDITY", ManifestEntry{9102, 1, DataTypes::FLOAT_T}},
-            {"AUGERSPEED", ManifestEntry{9103, 1, DataTypes::FLOAT_T}},
+            {"POSITION", ManifestEntry{9100, 1, DataTypes::FLOAT_T}},
+            {"AUGERSPEED", ManifestEntry{9101, 1, DataTypes::FLOAT_T}},
+            {"LIMITSWITCHTRIGGERED", ManifestEntry{9102, 1, DataTypes::UINT8_T}},
+            {"TEMPERATURE", ManifestEntry{9103, 1, DataTypes::FLOAT_T}},
+            {"HUMIDITY", ManifestEntry{9104, 1, DataTypes::FLOAT_T}},
         };
 
         // Error
@@ -347,13 +347,13 @@ namespace manifest
             {"WATCHDOGSTATUS", ManifestEntry{9200, 1, DataTypes::UINT8_T}},
             {"AUGERSTALLED", ManifestEntry{9201, 1, DataTypes::UINT8_T}},
         };
-    }    // namespace ScienceActuation
+    }    // namespace Auger
 
     /******************************************************************************
      * @brief Autonomy Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace Autonomy
     {
@@ -418,7 +418,7 @@ namespace manifest
      * @brief Camera1 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace Camera1
     {
@@ -449,7 +449,7 @@ namespace manifest
      * @brief Camera2 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace Camera2
     {
@@ -475,7 +475,7 @@ namespace manifest
      * @brief CameraServer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace CameraServer
     {
@@ -512,7 +512,7 @@ namespace manifest
      * @brief IRSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace IRSpectrometer
     {
@@ -528,44 +528,49 @@ namespace manifest
     }    // namespace IRSpectrometer
 
     /******************************************************************************
-     * @brief Instruments Board IP Address, Commands, Telemetry, and Error Packet 
+     * @brief Raman Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
-    namespace Instruments
+    namespace Raman
     {
         // IP Address
         const AddressEntry IP_ADDRESS{192, 168, 3, 105};
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"ENABLELEDS", ManifestEntry{16000, 1, DataTypes::UINT8_T}},
-            {"REQUESTRAMANREADING", ManifestEntry{16001, 1, DataTypes::UINT32_T}},
-            {"REQUESTREFLECTANCEREADING", ManifestEntry{16002, 1, DataTypes::UINT32_T}},
-            {"REQUESTTEMPERATURE", ManifestEntry{16003, 1, DataTypes::UINT8_T}},
+            {"INSTRUMENTSAXIS_OPENLOOP", ManifestEntry{16000, 1, DataTypes::INT16_T}},
+            {"INSTRUMENTSAXIS_SETPOSITION", ManifestEntry{16001, 1, DataTypes::FLOAT_T}},
+            {"INSTRUMENTSAXIS_INCREMENTPOSITION", ManifestEntry{16002, 1, DataTypes::FLOAT_T}},
+            {"LIMITSWITCHOVERRIDE", ManifestEntry{16003, 1, DataTypes::UINT8_T}},
+            {"CALIBRATEENCODER", ManifestEntry{16004, 1, DataTypes::UINT8_T}},
+            {"WATCHDOGOVERRIDE", ManifestEntry{16005, 1, DataTypes::UINT8_T}},
+            {"LASER", ManifestEntry{16006, 1, DataTypes::UINT8_T}},
+            {"REQUESTRAMANREADING", ManifestEntry{16007, 1, DataTypes::UINT32_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"RAMANREADING_PART1", ManifestEntry{16100, 500, DataTypes::UINT16_T}},
-            {"RAMANREADING_PART2", ManifestEntry{16101, 500, DataTypes::UINT16_T}},
-            {"RAMANREADING_PART3", ManifestEntry{16102, 500, DataTypes::UINT16_T}},
-            {"RAMANREADING_PART4", ManifestEntry{16103, 500, DataTypes::UINT16_T}},
-            {"RAMANREADING_PART5", ManifestEntry{16104, 48, DataTypes::UINT16_T}},
-            {"REFLECTANCEREADING", ManifestEntry{16105, 288, DataTypes::UINT8_T}},
-            {"TEMPERATURE", ManifestEntry{16106, 1, DataTypes::INT8_T}},
+            {"POSITION", ManifestEntry{16100, 1, DataTypes::FLOAT_T}},
+            {"LIMITSWITCHTRIGGERED", ManifestEntry{16101, 1, DataTypes::UINT8_T}},
+            {"RAMANREADING_PART1", ManifestEntry{16102, 512, DataTypes::UINT16_T}},
+            {"RAMANREADING_PART2", ManifestEntry{16103, 512, DataTypes::UINT16_T}},
+            {"RAMANREADING_PART3", ManifestEntry{16104, 512, DataTypes::UINT16_T}},
+            {"RAMANREADING_PART4", ManifestEntry{16105, 512, DataTypes::UINT16_T}},
         };
 
         // Error
-        const std::map<std::string, ManifestEntry> ERROR = {};
-    }    // namespace Instruments
+        const std::map<std::string, ManifestEntry> ERROR = {
+            {"WATCHDOGSTATUS", ManifestEntry{16200, 1, DataTypes::UINT8_T}},
+        };
+    }    // namespace Raman
 
     /******************************************************************************
      * @brief RoveSoSimulator Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace RoveSoSimulator
     {
@@ -587,7 +592,7 @@ namespace manifest
      * @brief RoveComm General Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace General
     {
@@ -602,7 +607,7 @@ namespace manifest
      * @brief RoveComm System Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace System
     {
@@ -618,7 +623,7 @@ namespace manifest
      * @brief RoveComm Helper Functions
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-01
+     * @date 2025-02-18
      ******************************************************************************/
     namespace Helpers
     {
@@ -712,18 +717,18 @@ namespace manifest
                         return GetDataTypeFromMap(Arm::ERROR, dataId);
                     }
                     break;
-                case 9:    // ScienceActuation Board
+                case 9:    // Auger Board
                     if (dataTypeCode == 0)
                     {
-                        return GetDataTypeFromMap(ScienceActuation::COMMANDS, dataId);
+                        return GetDataTypeFromMap(Auger::COMMANDS, dataId);
                     }
                     else if (dataTypeCode == 1)
                     {
-                        return GetDataTypeFromMap(ScienceActuation::TELEMETRY, dataId);
+                        return GetDataTypeFromMap(Auger::TELEMETRY, dataId);
                     }
                     else if (dataTypeCode == 2)
                     {
-                        return GetDataTypeFromMap(ScienceActuation::ERROR, dataId);
+                        return GetDataTypeFromMap(Auger::ERROR, dataId);
                     }
                     break;
                 case 11:    // Autonomy Board
@@ -782,18 +787,18 @@ namespace manifest
                         return GetDataTypeFromMap(CameraServer::ERROR, dataId);
                     }
                     break;
-                case 16:    // Instruments Board
+                case 16:    // Raman Board
                     if (dataTypeCode == 0)
                     {
-                        return GetDataTypeFromMap(Instruments::COMMANDS, dataId);
+                        return GetDataTypeFromMap(Raman::COMMANDS, dataId);
                     }
                     else if (dataTypeCode == 1)
                     {
-                        return GetDataTypeFromMap(Instruments::TELEMETRY, dataId);
+                        return GetDataTypeFromMap(Raman::TELEMETRY, dataId);
                     }
                     else if (dataTypeCode == 2)
                     {
-                        return GetDataTypeFromMap(Instruments::ERROR, dataId);
+                        return GetDataTypeFromMap(Raman::ERROR, dataId);
                     }
                     break;
                 case 99:    // RoveSoSimulator Board

--- a/src/RoveComm/RoveCommManifest.h
+++ b/src/RoveComm/RoveCommManifest.h
@@ -7,7 +7,7 @@
  *
  * @file RoveCommManifest.h
  * @author Missouri S&T - Mars Rover Design Team
- * @date 2025-02-20
+ * @date 2025-02-21
  *
  * @copyright Copyright Mars Rover Design Team 2025 - All Rights Reserved
  ******************************************************************************/
@@ -25,7 +25,7 @@ namespace manifest
      * @brief Enumeration of Data Types to be used in RoveComm
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     enum DataTypes
     {
@@ -44,7 +44,7 @@ namespace manifest
      * @brief IP Address Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     struct AddressEntry
     {
@@ -60,7 +60,7 @@ namespace manifest
      * @brief Manifest Entry Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     struct ManifestEntry
     {
@@ -74,7 +74,7 @@ namespace manifest
      * @brief Core Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace Core
     {
@@ -134,7 +134,7 @@ namespace manifest
      * @brief PMS Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace PMS
     {
@@ -174,7 +174,7 @@ namespace manifest
      * @brief Nav Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace Nav
     {
@@ -203,7 +203,7 @@ namespace manifest
      * @brief BaseStationNav Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace BaseStationNav
     {
@@ -222,7 +222,7 @@ namespace manifest
      * @brief SignalStack Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace SignalStack
     {
@@ -252,7 +252,7 @@ namespace manifest
      * @brief Arm Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace Arm
     {
@@ -311,7 +311,7 @@ namespace manifest
      * @brief Auger Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace Auger
     {
@@ -353,7 +353,7 @@ namespace manifest
      * @brief Autonomy Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace Autonomy
     {
@@ -419,7 +419,7 @@ namespace manifest
      * @brief Camera1 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace Camera1
     {
@@ -450,7 +450,7 @@ namespace manifest
      * @brief Camera2 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace Camera2
     {
@@ -476,7 +476,7 @@ namespace manifest
      * @brief CameraServer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace CameraServer
     {
@@ -513,7 +513,7 @@ namespace manifest
      * @brief IRSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace IRSpectrometer
     {
@@ -532,7 +532,7 @@ namespace manifest
      * @brief Raman Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace Raman
     {
@@ -571,7 +571,7 @@ namespace manifest
      * @brief RoveSoSimulator Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace RoveSoSimulator
     {
@@ -593,7 +593,7 @@ namespace manifest
      * @brief RoveComm General Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace General
     {
@@ -608,7 +608,7 @@ namespace manifest
      * @brief RoveComm System Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace System
     {
@@ -624,7 +624,7 @@ namespace manifest
      * @brief RoveComm Helper Functions
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-02-20
+     * @date 2025-02-21
      ******************************************************************************/
     namespace Helpers
     {

--- a/src/RoveComm/RoveCommPacket.h
+++ b/src/RoveComm/RoveCommPacket.h
@@ -29,8 +29,9 @@ typedef int ssize_t;
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
 #endif
-#include <winsock2.h>
+#include <mswsock.h>
 #include <windows.h>
+#include <winsock2.h>
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>

--- a/src/RoveComm/RoveCommPacket.h
+++ b/src/RoveComm/RoveCommPacket.h
@@ -29,6 +29,7 @@ typedef int ssize_t;
 #undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
 #endif
+#define _WINSOCKAPI_
 #include <mswsock.h>
 #include <windows.h>
 #include <winsock2.h>

--- a/src/RoveComm/RoveCommTCP.cpp
+++ b/src/RoveComm/RoveCommTCP.cpp
@@ -192,9 +192,11 @@ namespace rovecomm
 
         // Pack the data
         RoveCommData stData = PackPacket(stPacket);
-
         // Get size of data not including the data not filled. (the null/zero data in RoveCommData)
         size_t siDataSize = ROVECOMM_PACKET_HEADER_SIZE + (sizeof(T) * stPacket.unDataCount);
+
+        // Acquire a write lock on the socket send mutex to protect the socket, which is shared between threads, but not thread-safe.
+        std::unique_lock<std::mutex> lkSocketSendLock(m_muSocketSendMutex);
         // Send the data
 #if defined(__ROVECOMM_WINDOWS_MODE__) && __ROVECOMM_WINDOWS_MODE__ == 1
         ssize_t siBytesSent = send(nClientSocket, reinterpret_cast<char*>(&stData), siDataSize, 0);

--- a/src/RoveComm/RoveCommTCP.h
+++ b/src/RoveComm/RoveCommTCP.h
@@ -56,6 +56,7 @@ namespace rovecomm
             std::atomic_int m_nCurrentTCPClientSocket;
             struct sockaddr_in m_saClientAddr;
             std::shared_mutex m_muCallbackMutex;
+            std::mutex m_muSocketSendMutex;
 
             // Packet processing functions
             template<typename T>

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -187,8 +187,8 @@ namespace rovecomm
             }
         }
 
-        // Send the packet to the specified IP address and port if the destination IP is not 0.0.0.0
-        if (std::strcmp(cIPAddress, "0.0.0.0") == 0 && nPort != 0)
+        // Send the packet to the specified IP address and port.
+        if (std::strcmp(cIPAddress, "0.0.0.0") && nPort != 0)
         {
             saUDPClientAddr.sin_port = htons(nPort);
             inet_pton(AF_INET, cIPAddress, &saUDPClientAddr.sin_addr);

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -94,13 +94,33 @@ namespace rovecomm
         }
         else
         {
-            // Increase the socket buffer size to 10MB
+            // Increase the socket buffer size to 1MB
             int bufferSize = 1 * 1024 * 1024;
             if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_RCVBUF, &bufferSize, sizeof(bufferSize)) == -1)
             {
                 perror("Failed to set socket receive buffer size");
                 return false;
             }
+            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_SNDBUF, &bufferSize, sizeof(bufferSize)) == -1)
+            {
+                perror("Failed to set socket send buffer size");
+                return false;
+            }
+
+            // Set SO_REUSEADDR and SO_REUSEPORT
+            int optval = 1;
+            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == -1)
+            {
+                perror("Failed to set SO_REUSEADDR");
+                return false;
+            }
+#ifdef SO_REUSEPORT
+            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) == -1)
+            {
+                perror("Failed to set SO_REUSEPORT");
+                return false;
+            }
+#endif
 
 #if defined(__ROVECOMM_WINDOWS_MODE__) && __ROVECOMM_WINDOWS_MODE__ == 1
             u_long mode = 1;    // 1 to enable non-blocking mode
@@ -166,13 +186,14 @@ namespace rovecomm
         // Get size of data not including the data not filled. (the null/zero data in RoveCommData)
         size_t siDataSize = ROVECOMM_PACKET_HEADER_SIZE + (sizeof(T) * stPacket.unDataCount);
 
+        // Acquire a write lock on the socket send mutex to protect the socket, which is shared between threads, but not thread-safe.
+        std::unique_lock<std::mutex> lkSocketSendLock(m_muSocketSendMutex);
+
         // Setup the base UDP client address
         struct sockaddr_in saUDPClientAddr;
         memset(&saUDPClientAddr, 0, sizeof(saUDPClientAddr));
         saUDPClientAddr.sin_family = AF_INET;
 
-        // Acquire a write lock on the socket send mutex to protect the socket, which is shared between threads, but not thread-safe.
-        std::unique_lock<std::mutex> lkSocketSendLock(m_muSocketSendMutex);
         // Send the packet to all subscribers
         for (const SubscriberInfo& stSubscriber : vSubscribers)
         {
@@ -449,6 +470,8 @@ namespace rovecomm
 
         if (siUDPBytesReceived != -1)
         {
+            std::cout << "Received UDP bytes: " << siUDPBytesReceived << std::endl;
+
             // Extract the data id from the received data
             uint16_t unDataId = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);
             // Determine the data type from the received data

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -597,20 +597,34 @@ namespace rovecomm
         DWORD stdNumberOfBytesTransferred;
         ULONG_PTR ulCompletionKey;
         LPOVERLAPPED stdLPOverlapped;
+        // Set a short timeout (in milliseconds) to poll for completions.
+        const DWORD dwTimeout = 1;    // 1ms timeout (adjust as needed).
         while (true)
         {
-            BOOL bSuccess = GetQueuedCompletionStatus(m_stdIOCP, &stdNumberOfBytesTransferred, &ulCompletionKey, &stdLPOverlapped, INFINITE);
+            // Wait for an I/O completion event with a short timeout.
+            BOOL bSuccess = GetQueuedCompletionStatus(m_stdIOCP, &stdNumberOfBytesTransferred, &ulCompletionKey, &stdLPOverlapped, dwTimeout);
             if (!bSuccess)
             {
-                // You may want to handle errors and decide when to exit.
-                perror("GetQueuedCompletionStatus (recv) failed!");
+                if (GetLastError() == WAIT_TIMEOUT)
+                {
+                    // No completion available within the timeout period.
+                    break;    // Exit the loop so the function returns.
+                }
+                else
+                {
+                    perror("GetQueuedCompletionStatus (recv) failed!");
+                    continue;
+                }
+            }
+
+            // If stdLPOverlapped is NULL, something went wrong.
+            if (stdLPOverlapped == nullptr)
+            {
                 continue;
             }
 
             // Identify the RecvContext from the overlapped pointer.
             RecvContext* pContext = CONTAINING_RECORD(stdLPOverlapped, RecvContext, overlapped);
-
-            std::cout << "Received UDP bytes: " << stdNumberOfBytesTransferred << std::endl;
 
             // Process the received data.
             RoveCommData& stData      = pContext->data;
@@ -633,7 +647,7 @@ namespace rovecomm
                 case manifest::DataTypes::CHAR: ProcessPacket<char>(stData, udp::vCharCallbacks, saClientAddr); break;
             }
 
-            // Re-post the receive for this context.
+            // Re-post the asynchronous receive for this context.
             ZeroMemory(&pContext->overlapped, sizeof(OVERLAPPED));
             pContext->wsabuf.buf = reinterpret_cast<char*>(&pContext->data);
             pContext->wsabuf.len = sizeof(RoveCommData);

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -32,6 +32,39 @@ typedef int socket_t;
  ******************************************************************************/
 namespace rovecomm
 {
+#if defined(__ROVECOMM_WINDOWS_MODE__) && __ROVECOMM_WINDOWS_MODE__ == 1
+    /******************************************************************************
+     * @brief This struct is used to store the context for an asynchronous receive
+     *      operation. This is used to receive multiple packets at once.
+     *
+     *
+     * @author clayjay3 (claytonraycowen@gmail.com)
+     * @date 2025-02-18
+     ******************************************************************************/
+    struct RecvContext
+    {
+            OVERLAPPED overlapped;
+            RoveCommData data;
+            sockaddr_in addr;
+            WSABUF wsabuf;
+    };
+
+    /******************************************************************************
+     * @brief This struct is used to store the context for an asynchronous send
+     *      operation. This is used to send multiple packets at once.
+     *
+     *
+     * @author clayjay3 (claytonraycowen@gmail.com)
+     * @date 2025-02-18
+     ******************************************************************************/
+    struct SendContext
+    {
+            OVERLAPPED overlapped;
+            WSABUF wsabuf;
+            sockaddr_in addr;
+    };
+#endif
+
     /******************************************************************************
      * @brief Construct a new RoveCommUDP::RoveCommUDP object.
      *
@@ -96,12 +129,12 @@ namespace rovecomm
         {
             // Increase the socket buffer size to 1MB
             int bufferSize = 1 * 1024 * 1024;
-            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_RCVBUF, &bufferSize, sizeof(bufferSize)) == -1)
+            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_RCVBUF, (char*) &bufferSize, sizeof(bufferSize)) == -1)
             {
                 perror("Failed to set socket receive buffer size");
                 return false;
             }
-            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_SNDBUF, &bufferSize, sizeof(bufferSize)) == -1)
+            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_SNDBUF, (char*) &bufferSize, sizeof(bufferSize)) == -1)
             {
                 perror("Failed to set socket send buffer size");
                 return false;
@@ -109,13 +142,13 @@ namespace rovecomm
 
             // Set SO_REUSEADDR and SO_REUSEPORT
             int optval = 1;
-            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) == -1)
+            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_REUSEADDR, (char*) &optval, sizeof(optval)) == -1)
             {
                 perror("Failed to set SO_REUSEADDR");
                 return false;
             }
 #ifdef SO_REUSEPORT
-            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) == -1)
+            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_REUSEPORT, (char*) &optval, sizeof(optval)) == -1)
             {
                 perror("Failed to set SO_REUSEPORT");
                 return false;
@@ -123,12 +156,12 @@ namespace rovecomm
 #endif
 
 #if defined(__ROVECOMM_WINDOWS_MODE__) && __ROVECOMM_WINDOWS_MODE__ == 1
-            u_long mode = 1;    // 1 to enable non-blocking mode
-            if (ioctlsocket(m_nUDPSocket, FIONBIO, &mode) == SOCKET_ERROR)
+            // For asynchronous I/O, we use overlapped operations instead of non-blocking mode.
+            // Create an IOCP and associate our UDP socket with it.
+            m_stdIOCP = CreateIoCompletionPort((HANDLE) (SOCKET) m_nUDPSocket.load(), NULL, 0, 0);
+            if (m_stdIOCP == NULL)
             {
-                // Handle and print error.
-                int err = WSAGetLastError();
-                fprintf(stderr, "Failed to set UDP socket to non-blocking mode. Error code: %d\n", err);
+                perror("CreateIoCompletionPort failed.");
                 return false;
             }
 #else
@@ -467,11 +500,11 @@ namespace rovecomm
         for (size_t siIter = 0; siIter < BATCH_SIZE; siIter++)
         {
             ZeroMemory(&rcContexts[siIter].overlapped, sizeof(OVERLAPPED));
-            rcContexts[siInter].wsabuf.buf = reinterpret_cast<char*>(&rcContexts[siIter].data);
-            rcContexts[siIter].wsabuf.len  = sizeof(RoveCommData);
-            int nAddrLen                   = sizeof(rcContexts[siIter].addr);
-            DWORD stdFlags                 = 0;
-            int nRet                       = WSARecvFrom(m_nUDPSocket,
+            rcContexts[siIter].wsabuf.buf = reinterpret_cast<char*>(&rcContexts[siIter].data);
+            rcContexts[siIter].wsabuf.len = sizeof(RoveCommData);
+            int nAddrLen                  = sizeof(rcContexts[siIter].addr);
+            DWORD stdFlags                = 0;
+            int nRet                      = WSARecvFrom(m_nUDPSocket,
                                    &rcContexts[siIter].wsabuf,
                                    1,
                                    NULL,
@@ -493,10 +526,10 @@ namespace rovecomm
         // Wait for completions in a loop.
         DWORD stdNumberOfBytesTransferred;
         ULONG_PTR ulCompletionKey;
-        stdLPOverlapped stdLPOverlapped;
+        LPOVERLAPPED stdLPOverlapped;
         while (true)
         {
-            BOOL bSuccess = GetQueuedCompletionStatus(m_hIOCP, &stdNumberOfBytesTransferred, &ulCompletionKey, &stdLPOverlapped, INFINITE);
+            BOOL bSuccess = GetQueuedCompletionStatus(m_stdIOCP, &stdNumberOfBytesTransferred, &ulCompletionKey, &stdLPOverlapped, INFINITE);
             if (!bSuccess)
             {
                 // You may want to handle errors and decide when to exit.

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -94,6 +94,14 @@ namespace rovecomm
         }
         else
         {
+            // Increase the socket buffer size.
+            int bufferSize = 1024 * 1024;    // 1 MB
+            if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_RCVBUF, &bufferSize, sizeof(bufferSize)) == -1)
+            {
+                perror("Failed to set socket receive buffer size");
+                return false;
+            }
+
 #if defined(__ROVECOMM_WINDOWS_MODE__) && __ROVECOMM_WINDOWS_MODE__ == 1
             u_long mode = 1;    // 1 to enable non-blocking mode
             if (ioctlsocket(m_nUDPSocket, FIONBIO, &mode) == SOCKET_ERROR)

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -219,9 +219,7 @@ namespace rovecomm
         // Get size of data not including the data not filled. (the null/zero data in RoveCommData)
         size_t siDataSize = ROVECOMM_PACKET_HEADER_SIZE + (sizeof(T) * stPacket.unDataCount);
 
-        // Acquire a write lock on the socket send mutex to protect the socket, which is shared between threads, but not thread-safe.
-        std::unique_lock<std::mutex> lkSocketSendLock(m_muSocketSendMutex);
-
+#if defined(__ROVECOMM_WINDOWS_MODE__) && __ROVECOMM_WINDOWS_MODE__ == 1
         // Setup the base UDP client address
         struct sockaddr_in saUDPClientAddr;
         memset(&saUDPClientAddr, 0, sizeof(saUDPClientAddr));
@@ -233,12 +231,16 @@ namespace rovecomm
             // Assemble client address.
             saUDPClientAddr.sin_port = htons(stSubscriber.nPort);
             inet_pton(AF_INET, stSubscriber.szIPAddress.c_str(), &saUDPClientAddr.sin_addr);
+            // Acquire a write lock on the socket send mutex to protect the socket, which is shared between threads, but not thread-safe.
+            std::unique_lock<std::mutex> lkSocketSendLock(m_muSocketSendMutex);
             // Send data.
             if (sendto(m_nUDPSocket, reinterpret_cast<char*>(&stData), siDataSize, 0, (struct sockaddr*) &saUDPClientAddr, sizeof(saUDPClientAddr)) == -1)
             {
                 // Handle and print error message.
                 perror("Failed to send data to UDP client socket subscriber.");
             }
+            // Release the lock.
+            lkSocketSendLock.unlock();
         }
 
         // Send the packet to the specified IP address and port.
@@ -247,10 +249,78 @@ namespace rovecomm
             saUDPClientAddr.sin_port = htons(nPort);
             inet_pton(AF_INET, cIPAddress, &saUDPClientAddr.sin_addr);
 
+            // Acquire a write lock on the socket send mutex to protect the socket, which is shared between threads, but not thread-safe.
+            std::unique_lock<std::mutex> lkSocketSendLock(m_muSocketSendMutex);
             return sendto(m_nUDPSocket, reinterpret_cast<char*>(&stData), siDataSize, 0, (struct sockaddr*) &saUDPClientAddr, sizeof(saUDPClientAddr));
         }
 
         return -1;
+#else
+        // Use sendmmsg to send the same packet to multiple destinations in one call.
+        std::vector<sockaddr_in> vDestinations;
+        // Add all subscribers.
+        for (const SubscriberInfo& stSubscriber : vSubscribers)
+        {
+            // Assemble client address.
+            sockaddr_in stdAddr{};
+            stdAddr.sin_family = AF_INET;
+            stdAddr.sin_port   = htons(stSubscriber.nPort);
+            // Convert the IP address to binary form.
+            inet_pton(AF_INET, stSubscriber.szIPAddress.c_str(), &stdAddr.sin_addr);
+            // Add the subscriber to the list of destinations.
+            vDestinations.push_back(stdAddr);
+        }
+        // Add the specified destination if provided.
+        if (std::strcmp(cIPAddress, "0.0.0.0") != 0 && nPort != 0)
+        {
+            // Assemble client address.
+            sockaddr_in stdAddr{};
+            stdAddr.sin_family = AF_INET;
+            stdAddr.sin_port   = htons(nPort);
+            // Convert the IP address to binary form.
+            inet_pton(AF_INET, cIPAddress, &stdAddr.sin_addr);
+            // Add the specified destination to the list of destinations.
+            vDestinations.push_back(stdAddr);
+        }
+
+        // Send the packet to all destinations.
+        if (vDestinations.empty())
+        {
+            return -1;
+        }
+
+        // Get the number of destinations and create the necessary data structures.
+        size_t siCount = vDestinations.size();
+        std::vector<struct mmsghdr> vMsgVec(siCount);
+        std::vector<struct iovec> vIOVecs(siCount);
+        // Send the packet to all destinations.
+        for (size_t siIter = 0; siIter < siCount; siIter++)
+        {
+            // Set the data to be sent.
+            vIOVecs[siIter].iov_base = reinterpret_cast<char*>(&stData);
+            vIOVecs[siIter].iov_len  = siDataSize;
+            memset(&vMsgVec[siIter], 0, sizeof(struct mmsghdr));
+            // Set the destination address.
+            vMsgVec[siIter].msg_hdr.msg_iov    = &vIOVecs[siIter];
+            vMsgVec[siIter].msg_hdr.msg_iovlen = 1;
+            vMsgVec[siIter].msg_hdr.msg_name   = &vDestinations[siIter];
+            // Set the length of the destination address.
+            vMsgVec[siIter].msg_hdr.msg_namelen = sizeof(sockaddr_in);
+        }
+
+        // Acquire a write lock on the socket send mutex to protect the socket, which is shared between threads, but not thread-safe.
+        std::unique_lock<std::mutex> lkSocketSendLock(m_muSocketSendMutex);
+        // Send the packet to all destinations.
+        int nSentMessages = sendmmsg(m_nUDPSocket, vMsgVec.data(), siCount, 0);
+        if (nSentMessages == -1)
+        {
+            perror("sendmmsg error");
+            return -1;
+        }
+
+        // Return the number of packets sent.
+        return nSentMessages;
+#endif
     }
 
     /******************************************************************************

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -163,6 +163,8 @@ namespace rovecomm
         memset(&saUDPClientAddr, 0, sizeof(saUDPClientAddr));
         saUDPClientAddr.sin_family = AF_INET;
 
+        // Acquire a write lock on the socket send mutex to protect the socket, which is shared between threads, but not thread-safe.
+        std::unique_lock<std::mutex> lkSocketSendLock(m_muSocketSendMutex);
         // Send the packet to all subscribers
         for (const SubscriberInfo& stSubscriber : vSubscribers)
         {
@@ -177,8 +179,8 @@ namespace rovecomm
             }
         }
 
-        // Send the packet to the specified IP address and port
-        if (std::strcmp(cIPAddress, "0.0.0.0") && nPort != 0)
+        // Send the packet to the specified IP address and port if the destination IP is not 0.0.0.0
+        if (std::strcmp(cIPAddress, "0.0.0.0") == 0 && nPort != 0)
         {
             saUDPClientAddr.sin_port = htons(nPort);
             inet_pton(AF_INET, cIPAddress, &saUDPClientAddr.sin_addr);

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -458,27 +458,142 @@ namespace rovecomm
      ******************************************************************************/
     void RoveCommUDP::ReceiveUDPPacketAndCallback()
     {
-        RoveCommData stData;
-        sockaddr_in saClientAddr;
-        socklen_t addrLen = sizeof(saClientAddr);
-
 #if defined(__ROVECOMM_WINDOWS_MODE__) && __ROVECOMM_WINDOWS_MODE__ == 1
-        ssize_t siUDPBytesReceived = recvfrom(m_nUDPSocket, reinterpret_cast<char*>(&stData), sizeof(stData), 0, (struct sockaddr*) &saClientAddr, &addrLen);
-#else
-        ssize_t siUDPBytesReceived = recvfrom(m_nUDPSocket, &stData, sizeof(stData), MSG_DONTWAIT, (struct sockaddr*) &saClientAddr, &addrLen);
-#endif
+        // Create a batch of RecvContext structures to receive multiple packets at once.
+        constexpr size_t BATCH_SIZE = 32;
+        RecvContext rcContexts[BATCH_SIZE];
 
-        if (siUDPBytesReceived != -1)
+        // Post BATCH_SIZE asynchronous receives.
+        for (size_t siIter = 0; siIter < BATCH_SIZE; siIter++)
         {
-            std::cout << "Received UDP bytes: " << siUDPBytesReceived << std::endl;
+            ZeroMemory(&rcContexts[siIter].overlapped, sizeof(OVERLAPPED));
+            rcContexts[siInter].wsabuf.buf = reinterpret_cast<char*>(&rcContexts[siIter].data);
+            rcContexts[siIter].wsabuf.len  = sizeof(RoveCommData);
+            int nAddrLen                   = sizeof(rcContexts[siIter].addr);
+            DWORD stdFlags                 = 0;
+            int nRet                       = WSARecvFrom(m_nUDPSocket,
+                                   &rcContexts[siIter].wsabuf,
+                                   1,
+                                   NULL,
+                                   &stdFlags,
+                                   reinterpret_cast<sockaddr*>(&rcContexts[siIter].addr),
+                                   &nAddrLen,
+                                   &rcContexts[siIter].overlapped,
+                                   NULL);
+            if (nRet == SOCKET_ERROR)
+            {
+                int nErr = WSAGetLastError();
+                if (nErr != WSA_IO_PENDING)
+                {
+                    perror("WSARecvFrom failed!");
+                }
+            }
+        }
 
-            // Extract the data id from the received data
-            uint16_t unDataId = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);
-            // Determine the data type from the received data
-            // manifest::DataTypes eDataType = manifest::Helpers::GetDataTypeFromId(unDataId);
+        // Wait for completions in a loop.
+        DWORD stdNumberOfBytesTransferred;
+        ULONG_PTR ulCompletionKey;
+        stdLPOverlapped stdLPOverlapped;
+        while (true)
+        {
+            BOOL bSuccess = GetQueuedCompletionStatus(m_hIOCP, &stdNumberOfBytesTransferred, &ulCompletionKey, &stdLPOverlapped, INFINITE);
+            if (!bSuccess)
+            {
+                // You may want to handle errors and decide when to exit.
+                perror("GetQueuedCompletionStatus (recv) failed!");
+                continue;
+            }
+
+            // Identify the RecvContext from the overlapped pointer.
+            RecvContext* pContext = CONTAINING_RECORD(stdLPOverlapped, RecvContext, overlapped);
+
+            std::cout << "Received UDP bytes: " << stdNumberOfBytesTransferred << std::endl;
+
+            // Process the received data.
+            RoveCommData& stData      = pContext->data;
+            sockaddr_in& saClientAddr = pContext->addr;
+
+            // Extract data id and data type from the packet.
+            uint16_t unDataId             = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);
             manifest::DataTypes eDataType = static_cast<manifest::DataTypes>(stData.unBytes[5]);
 
-            // Convert RoveCommData to appropriate RoveCommPacket based on data type
+            switch (eDataType)
+            {
+                case manifest::DataTypes::UINT8_T: ProcessPacket<uint8_t>(stData, udp::vUInt8Callbacks, saClientAddr); break;
+                case manifest::DataTypes::INT8_T: ProcessPacket<int8_t>(stData, udp::vInt8Callbacks, saClientAddr); break;
+                case manifest::DataTypes::UINT16_T: ProcessPacket<uint16_t>(stData, udp::vUInt16Callbacks, saClientAddr); break;
+                case manifest::DataTypes::INT16_T: ProcessPacket<int16_t>(stData, udp::vInt16Callbacks, saClientAddr); break;
+                case manifest::DataTypes::UINT32_T: ProcessPacket<uint32_t>(stData, udp::vUInt32Callbacks, saClientAddr); break;
+                case manifest::DataTypes::INT32_T: ProcessPacket<int32_t>(stData, udp::vInt32Callbacks, saClientAddr); break;
+                case manifest::DataTypes::FLOAT_T: ProcessPacket<float>(stData, udp::vFloatCallbacks, saClientAddr); break;
+                case manifest::DataTypes::DOUBLE_T: ProcessPacket<double>(stData, udp::vDoubleCallbacks, saClientAddr); break;
+                case manifest::DataTypes::CHAR: ProcessPacket<char>(stData, udp::vCharCallbacks, saClientAddr); break;
+            }
+
+            // Re-post the receive for this context.
+            ZeroMemory(&pContext->overlapped, sizeof(OVERLAPPED));
+            pContext->wsabuf.buf = reinterpret_cast<char*>(&pContext->data);
+            pContext->wsabuf.len = sizeof(RoveCommData);
+            int nAddrLen         = sizeof(pContext->addr);
+            DWORD stdFlags       = 0;
+            int nRet =
+                WSARecvFrom(m_nUDPSocket, &pContext->wsabuf, 1, NULL, &stdFlags, reinterpret_cast<sockaddr*>(&pContext->addr), &nAddrLen, &pContext->overlapped, NULL);
+            if (nRet == SOCKET_ERROR)
+            {
+                int nErr = WSAGetLastError();
+                if (nErr != WSA_IO_PENDING)
+                {
+                    perror("WSARecvFrom (re-post) failed!");
+                }
+            }
+        }
+#else
+        // Create a batch of RoveCommData structures to receive multiple packets at once.
+        constexpr size_t BATCH_SIZE = 32;
+        RoveCommData aDataBatch[BATCH_SIZE];
+        struct iovec aIOVecs[BATCH_SIZE];
+        struct mmsghdr aMsgVec[BATCH_SIZE];
+        sockaddr_in aAddrs[BATCH_SIZE];
+
+        // Initialize the aIOVecs and aMsgVec arrays. These are used by the recvmmsg function.
+        memset(aMsgVec, 0, sizeof(aMsgVec));
+        for (size_t siIter = 0; siIter < BATCH_SIZE; siIter++)
+        {
+            aIOVecs[siIter].iov_base            = &aDataBatch[siIter];
+            aIOVecs[siIter].iov_len             = sizeof(RoveCommData);
+            aMsgVec[siIter].msg_hdr.msg_iov     = &aIOVecs[siIter];
+            aMsgVec[siIter].msg_hdr.msg_iovlen  = 1;
+            aMsgVec[siIter].msg_hdr.msg_name    = &aAddrs[siIter];
+            aMsgVec[siIter].msg_hdr.msg_namelen = sizeof(sockaddr_in);
+        }
+
+        // Acquire a write lock on the socket receive mutex to protect the socket, which is shared between threads, but not thread-safe.
+        std::unique_lock<std::mutex> lkSocketReceiveLock(m_muSocketReceiveMutex);
+
+        // Receive a batch of packets.
+        int nRet = recvmmsg(m_nUDPSocket, aMsgVec, BATCH_SIZE, MSG_DONTWAIT, nullptr);
+        if (nRet < 0)
+        {
+            if (errno != EAGAIN && errno != EWOULDBLOCK)
+            {
+                perror("Failed to receive data from UDP socket using recvmmsg.");
+            }
+            return;
+        }
+        // Release the lock.
+        lkSocketReceiveLock.unlock();
+
+        // Process each received packet.
+        for (int nIter = 0; nIter < nRet; nIter++)
+        {
+            // Get the data and client address from the received packet.
+            RoveCommData& stData      = aDataBatch[nIter];
+            sockaddr_in& saClientAddr = aAddrs[nIter];
+
+            // Extract the data id and data type from the packet.
+            uint16_t unDataId             = (static_cast<uint16_t>(stData.unBytes[1]) << 8) | static_cast<uint16_t>(stData.unBytes[2]);
+            manifest::DataTypes eDataType = static_cast<manifest::DataTypes>(stData.unBytes[5]);
+
             switch (eDataType)
             {
                 case manifest::DataTypes::UINT8_T: ProcessPacket<uint8_t>(stData, udp::vUInt8Callbacks, saClientAddr); break;
@@ -492,6 +607,7 @@ namespace rovecomm
                 case manifest::DataTypes::CHAR: ProcessPacket<char>(stData, udp::vCharCallbacks, saClientAddr); break;
             }
         }
+#endif
     }
 
     /******************************************************************************
@@ -554,7 +670,10 @@ namespace rovecomm
      ******************************************************************************/
     void RoveCommUDP::ThreadedContinuousCode()
     {
-        ReceiveUDPPacketAndCallback();
+        // Start the thread pool to receive multiple packets at once.
+        this->RunDetachedPool(10, 5);
+        // Wait for thread pool to finish.
+        this->JoinPool();
     }
 
     /******************************************************************************
@@ -568,7 +687,10 @@ namespace rovecomm
      * @author Eli Byrd (edbgkk@mst.edu)
      * @date 2024-02-07
      ******************************************************************************/
-    void RoveCommUDP::PooledLinearCode() {}
+    void RoveCommUDP::PooledLinearCode()
+    {
+        ReceiveUDPPacketAndCallback();
+    }
 
     /******************************************************************************
      * @brief Close the UDP socket. This method is called when the RoveCommUDP

--- a/src/RoveComm/RoveCommUDP.cpp
+++ b/src/RoveComm/RoveCommUDP.cpp
@@ -94,8 +94,8 @@ namespace rovecomm
         }
         else
         {
-            // Increase the socket buffer size.
-            int bufferSize = 1024 * 1024;    // 1 MB
+            // Increase the socket buffer size to 10MB
+            int bufferSize = 1 * 1024 * 1024;
             if (setsockopt(m_nUDPSocket, SOL_SOCKET, SO_RCVBUF, &bufferSize, sizeof(bufferSize)) == -1)
             {
                 perror("Failed to set socket receive buffer size");

--- a/src/RoveComm/RoveCommUDP.h
+++ b/src/RoveComm/RoveCommUDP.h
@@ -56,6 +56,7 @@ namespace rovecomm
             std::vector<SubscriberInfo> vSubscribers;
             std::shared_mutex m_muCallbackMutex;
             std::mutex m_muSocketSendMutex;
+            std::mutex m_muSocketReceiveMutex;
 
             // Packet processing functions
             template<typename T>

--- a/src/RoveComm/RoveCommUDP.h
+++ b/src/RoveComm/RoveCommUDP.h
@@ -55,6 +55,7 @@ namespace rovecomm
             struct sockaddr_in m_saUDPServerAddr;
             std::vector<SubscriberInfo> vSubscribers;
             std::shared_mutex m_muCallbackMutex;
+            std::mutex m_muSocketSendMutex;
 
             // Packet processing functions
             template<typename T>

--- a/src/RoveComm/RoveCommUDP.h
+++ b/src/RoveComm/RoveCommUDP.h
@@ -50,6 +50,11 @@ namespace rovecomm
     class RoveCommUDP : AutonomyThread<void>
     {
         private:
+#if defined(__ROVECOMM_WINDOWS_MODE__) && __ROVECOMM_WINDOWS_MODE__ == 1
+            // Windows specific private member variables.
+            HANDLE m_stdIOCP;
+#endif
+
             // Private member variables
             std::atomic_int m_nUDPSocket;
             struct sockaddr_in m_saUDPServerAddr;

--- a/src/interfaces/AutonomyThread.hpp
+++ b/src/interfaces/AutonomyThread.hpp
@@ -14,12 +14,13 @@
 #ifndef AUTONOMYTHREAD_H
 #define AUTONOMYTHREAD_H
 
-#include "../../external/threadpool/include/BS_thread_pool.hpp"
 #include "../util/IPS.hpp"
 
 /// \cond
+#include "../../external/threadpool/include/BS_thread_pool.hpp"
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <vector>
 
 /// \endcond
@@ -41,7 +42,7 @@ class AutonomyThread
         /////////////////////////////////////////
 
         // Define an enum for storing this classes state.
-        enum AutonomyThreadState
+        enum class AutonomyThreadState
         {
             eStarting,
             eRunning,
@@ -63,7 +64,7 @@ class AutonomyThread
         {
             // Initialize member variables.
             m_bStopThreads                     = false;
-            m_eThreadState                     = eStopped;
+            m_eThreadState                     = AutonomyThreadState::eStopped;
             m_nMainThreadMaxIterationPerSecond = 0;
         }
 
@@ -82,7 +83,7 @@ class AutonomyThread
             // Tell all threads to stop executing user code.
             m_bStopThreads = true;
             // Update thread state.
-            m_eThreadState = eStopping;
+            m_eThreadState = AutonomyThreadState::eStopping;
 
             // Pause and clear pool queues.
             m_thPool.pause();
@@ -94,7 +95,7 @@ class AutonomyThread
             m_thPool.wait();
             m_thMainThread.wait();
             // Update thread state.
-            m_eThreadState = eStopped;
+            m_eThreadState = AutonomyThreadState::eStopped;
         }
 
         /******************************************************************************
@@ -108,6 +109,7 @@ class AutonomyThread
          *      If you want to wait until they fully execute their code, then call the Join()
          *      method before starting a new thread.
          *
+         * @note This method will block until the thread state is eRunning.
          *
          * @author ClayJay3 (claytonraycowen@gmail.com)
          * @date 2023-07-22
@@ -117,7 +119,7 @@ class AutonomyThread
             // Tell any open thread to stop.
             m_bStopThreads = true;
             // Update thread state.
-            m_eThreadState = eStopping;
+            m_eThreadState = AutonomyThreadState::eStopping;
 
             // Pause queuing of new tasks to the threads, then purge them.
             m_thPool.pause();
@@ -129,7 +131,7 @@ class AutonomyThread
             this->Join();
 
             // Update thread state.
-            m_eThreadState = eStarting;
+            m_eThreadState = AutonomyThreadState::eStarting;
             // Clear results vector.
             m_vPoolReturns.clear();
             // Reset thread stop toggle.
@@ -141,6 +143,12 @@ class AutonomyThread
             // Unpause pool queues.
             m_thPool.unpause();
             m_thMainThread.unpause();
+
+            // Block until thread is started or currently stopping if thread start failed.
+            std::unique_lock<std::mutex> lkStartLock(m_muThreadRunningConditionMutex);
+            m_cdThreadRunningCondition.wait(lkStartLock,
+                                            [this]
+                                            { return this->m_eThreadState == AutonomyThreadState::eRunning || this->m_eThreadState == AutonomyThreadState::eStopping; });
         }
 
         /******************************************************************************
@@ -158,7 +166,7 @@ class AutonomyThread
             // Signal for any open threads to stop executing,
             m_bStopThreads = true;
             // Update thread state.
-            m_eThreadState = eStopping;
+            m_eThreadState = AutonomyThreadState::eStopping;
         }
 
         /******************************************************************************
@@ -177,7 +185,7 @@ class AutonomyThread
             m_thMainThread.wait();
 
             // Update thread state.
-            m_eThreadState = eStopped;
+            m_eThreadState = AutonomyThreadState::eStopped;
         }
 
         /******************************************************************************
@@ -191,18 +199,8 @@ class AutonomyThread
          * @date 2023-07-22
          ******************************************************************************/
         bool Joinable() const
-        {
-            // Check current number of running and queued tasks.
-            if (m_thMainThread.get_tasks_total() <= 0 && m_thPool.get_tasks_total() <= 0)
-            {
-                // Threads are joinable.
-                return true;
-            }
-            else
-            {
-                // Threads are still running.
-                return false;
-            }
+        {    // Check current number of running and queued tasks.
+            return (m_thMainThread.get_tasks_total() <= 0 && m_thPool.get_tasks_total() <= 0);
         }
 
         /******************************************************************************
@@ -268,9 +266,6 @@ class AutonomyThread
             // Check if the pools need to be resized.
             if (m_thPool.get_thread_count() != nNumThreads)
             {
-                // Tell any open thread to stop.
-                m_bStopThreads = true;
-
                 // Pause queuing of new tasks to the threads, then purge them.
                 m_thPool.pause();
                 m_thPool.purge();
@@ -281,15 +276,10 @@ class AutonomyThread
 
                 // Clear results vector.
                 m_vPoolReturns.clear();
-                // Reset thread stop toggle.
-                m_bStopThreads = false;
             }
             // Check if the current pool tasks should be stopped before queueing more tasks.
             else if (bForceStopCurrentThreads)
             {
-                // Tell any open thread to stop.
-                m_bStopThreads = true;
-
                 // Pause queuing of new tasks to the threads, then purge them.
                 m_thPool.pause();
                 m_thPool.purge();
@@ -297,9 +287,6 @@ class AutonomyThread
                 m_thPool.wait();
                 // Unpause queue.
                 m_thPool.unpause();
-
-                // Reset stop toggle.
-                m_bStopThreads = false;
             }
 
             // Loop nNumThreads times and queue tasks.
@@ -351,9 +338,6 @@ class AutonomyThread
             // Check if the pools need to be resized.
             if (m_thPool.get_thread_count() != nNumThreads)
             {
-                // Tell any open thread to stop.
-                m_bStopThreads = true;
-
                 // Pause queuing of new tasks to the threads, then purge them.
                 m_thPool.pause();
                 m_thPool.purge();
@@ -364,15 +348,10 @@ class AutonomyThread
 
                 // Clear results vector.
                 m_vPoolReturns.clear();
-                // Reset thread stop toggle.
-                m_bStopThreads = false;
             }
             // Check if the current pool tasks should be stopped before queueing more tasks.
             else if (bForceStopCurrentThreads)
             {
-                // Tell any open thread to stop.
-                m_bStopThreads = true;
-
                 // Pause queuing of new tasks to the threads, then purge them.
                 m_thPool.pause();
                 m_thPool.purge();
@@ -380,9 +359,6 @@ class AutonomyThread
                 m_thPool.wait();
                 // Unpause queue.
                 m_thPool.unpause();
-
-                // Reset stop toggle.
-                m_bStopThreads = false;
             }
 
             // Loop nNumThreads times and queue tasks.
@@ -430,11 +406,12 @@ class AutonomyThread
             // Create new thread pool.
             BS::thread_pool m_thLoopPool = BS::thread_pool(nNumThreads);
 
-            m_thLoopPool.detach_blocks(tTotalIterations,
-                                       [&tLoopFunction](const int a, const int b)
+            m_thLoopPool.detach_blocks(0,
+                                       tTotalIterations,
+                                       [&tLoopFunction](const int nStart, const int nEnd)
                                        {
                                            // Call loop function without lock.
-                                           tLoopFunction(a, b);
+                                           tLoopFunction(nStart, nEnd);
                                        });
 
             // Wait for loop to finish.
@@ -474,16 +451,7 @@ class AutonomyThread
         bool PoolJoinable() const
         {
             // Check current number of running and queued tasks.
-            if (m_thPool.get_tasks_total() <= 0)
-            {
-                // Threads are joinable.
-                return true;
-            }
-            else
-            {
-                // Threads are still running.
-                return false;
-            }
+            return (m_thPool.get_tasks_total() <= 0);
         }
 
         /******************************************************************************
@@ -576,6 +544,8 @@ class AutonomyThread
         std::vector<std::future<T>> m_vPoolReturns;
         std::atomic_bool m_bStopThreads;
         std::atomic<AutonomyThreadState> m_eThreadState;
+        std::mutex m_muThreadRunningConditionMutex;
+        std::condition_variable m_cdThreadRunningCondition;
         int m_nMainThreadMaxIterationPerSecond;
 
         /////////////////////////////////////////
@@ -601,7 +571,7 @@ class AutonomyThread
         void RunThread(std::atomic_bool& bStopThread)
         {
             // Declare instance variables.
-            std::chrono::high_resolution_clock::time_point tmStartTime;
+            std::chrono::_V2::system_clock::time_point tmStartTime;
 
             // Loop until stop flag is set.
             while (!bStopThread)
@@ -620,7 +590,7 @@ class AutonomyThread
                 if (m_nMainThreadMaxIterationPerSecond > 0)
                 {
                     // Get end execution time.
-                    std::chrono::high_resolution_clock::time_point tmEndTime = std::chrono::high_resolution_clock::now();
+                    std::chrono::_V2::system_clock::time_point tmEndTime = std::chrono::high_resolution_clock::now();
                     // Get execution time of user code.
                     std::chrono::microseconds tmElapsedTime = std::chrono::duration_cast<std::chrono::microseconds>(tmEndTime - tmStartTime);
                     // Check if the elapsed time is slower than the max iterations per seconds.
@@ -634,16 +604,21 @@ class AutonomyThread
                 }
 
                 // Check if thread state needs to be updated.
-                if (m_eThreadState != eRunning && m_eThreadState != eStopping)
+                if (m_eThreadState != AutonomyThreadState::eRunning && m_eThreadState != AutonomyThreadState::eStopping)
                 {
                     // Update thread state to running.
-                    m_eThreadState = eRunning;
+                    m_eThreadState = AutonomyThreadState::eRunning;
+                    // Notify waiting start method that thread is now running.
+                    m_cdThreadRunningCondition.notify_all();
                 }
 
                 // Call iteration per second tracking tick.
                 m_IPS.Tick();
             }
+
+            // Notify waiting start method that thread is now stopping.
+            m_cdThreadRunningCondition.notify_all();
         }
 };
 
-#endif    // AUTONOMYTHREAD_H
+#endif

--- a/src/interfaces/AutonomyThread.hpp
+++ b/src/interfaces/AutonomyThread.hpp
@@ -571,7 +571,7 @@ class AutonomyThread
         void RunThread(std::atomic_bool& bStopThread)
         {
             // Declare instance variables.
-            std::chrono::_V2::system_clock::time_point tmStartTime;
+            std::chrono::high_resolution_clock::time_point tmStartTime;
 
             // Loop until stop flag is set.
             while (!bStopThread)
@@ -590,7 +590,7 @@ class AutonomyThread
                 if (m_nMainThreadMaxIterationPerSecond > 0)
                 {
                     // Get end execution time.
-                    std::chrono::_V2::system_clock::time_point tmEndTime = std::chrono::high_resolution_clock::now();
+                    std::chrono::high_resolution_clock::time_point tmEndTime = std::chrono::high_resolution_clock::now();
                     // Get execution time of user code.
                     std::chrono::microseconds tmElapsedTime = std::chrono::duration_cast<std::chrono::microseconds>(tmEndTime - tmStartTime);
                     // Check if the elapsed time is slower than the max iterations per seconds.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,6 +132,10 @@ int main()
     // Wait for packets to be processed.
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
+    // Close the UDP and TCP sockets
+    pRoveCommUDP_Node.CloseUDPSocket();
+    pRoveCommTCP_Node.CloseTCPSocket();
+
     exit(0);
 }
 

--- a/tests/Unit/src/udp.cc
+++ b/tests/Unit/src/udp.cc
@@ -110,9 +110,14 @@ TEST(RoveCommUDP, SendUDPPacket)
 
                 // Send the packet to the localhost
                 ssize_t siBytesSent = pRoveCommUDP_Node.SendUDPPacket<uint8_t>(stPacket, "127.0.0.1", 11001);
+                // Check if the packet successfully sent.
+                EXPECT_EQ(siBytesSent, 1);
 
-                // Check if the packet successfully sent
-                EXPECT_EQ(siBytesSent, ROVECOMM_PACKET_HEADER_SIZE + (sizeof(uint8_t) * stPacket.unDataCount));
+                // Send two packets to the localhost
+                ssize_t siBytesSent1 = pRoveCommUDP_Node.SendUDPPacket<uint8_t>(stPacket, "127.0.0.1", 11001);
+                ssize_t siBytesSent2 = pRoveCommUDP_Node.SendUDPPacket<uint8_t>(stPacket, "127.0.0.1", 11001);
+                // Check if the packets successfully sent.
+                EXPECT_EQ(siBytesSent1 + siBytesSent2, 2);
 
                 // Close the socket
                 pRoveCommUDP_Node.CloseUDPSocket();


### PR DESCRIPTION
This PR partially resolves a critical issue causing packet loss/corruption and optimizes socket performance across platforms. Packet loss is still possible if the operating system's send or receive buffer is overloaded. The OS's buffer is different from the 1MB buffer size set in the RoveComm_CPP code.

Key changes include:  

1. **Socket Buffer & Logic Fixes**  
   - Increased socket receive buffer sizes to reduce packet drops under high load.  
   - Adjusted socket options and corrected logic errors in the receive handling.  
   - Leveraged Linux’s `sendmmsg` for batched packet transmission, improving throughput.  

2. **Windows-Specific Fixes**  
   - Resolved compile errors and macro redefinition conflicts.  
   - Tested/validated socket configuration changes for Windows compatibility.  

3. **Miscellaneous Updates**  
   - Updated submodule dependencies and manifests to align with new logic.  
   - Added a new packet type to clear obstacles for autonomy.

**Testing**: Changes were validated on both Linux and Windows to ensure stability and performance gains.