### PR TITLE
Fix Generate Manifest Action

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: ["development"]
     paths:
-      - "data/RoveComm/manifest.json"
+      - "data/RoveComm/**" # Watch all changes in the submodule
       - "tools/RoveComm/parser.py"
       - "src/RoveComm/RoveCommManifest.h"
       - ".github/workflows/manifest.yml"

--- a/src/RoveComm/RoveCommManifest.h
+++ b/src/RoveComm/RoveCommManifest.h
@@ -7,7 +7,7 @@
  *
  * @file RoveCommManifest.h
  * @author Missouri S&T - Mars Rover Design Team
- * @date 2025-04-07
+ * @date 2025-04-21
  *
  * @copyright Copyright Mars Rover Design Team 2025 - All Rights Reserved
  ******************************************************************************/
@@ -25,7 +25,7 @@ namespace manifest
      * @brief Enumeration of Data Types to be used in RoveComm
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     enum DataTypes
     {
@@ -44,7 +44,7 @@ namespace manifest
      * @brief IP Address Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     struct AddressEntry
     {
@@ -60,7 +60,7 @@ namespace manifest
      * @brief Manifest Entry Object for RoveComm.
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     struct ManifestEntry
     {
@@ -74,7 +74,7 @@ namespace manifest
      * @brief Core Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace Core
     {
@@ -134,7 +134,7 @@ namespace manifest
      * @brief PMS Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace PMS
     {
@@ -174,7 +174,7 @@ namespace manifest
      * @brief Nav Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace Nav
     {
@@ -203,7 +203,7 @@ namespace manifest
      * @brief BaseStationNav Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace BaseStationNav
     {
@@ -222,7 +222,7 @@ namespace manifest
      * @brief SignalStack Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace SignalStack
     {
@@ -252,7 +252,7 @@ namespace manifest
      * @brief Arm Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace Arm
     {
@@ -311,7 +311,7 @@ namespace manifest
      * @brief Auger Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace Auger
     {
@@ -353,7 +353,7 @@ namespace manifest
      * @brief Autonomy Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace Autonomy
     {
@@ -419,12 +419,9 @@ namespace manifest
             NOTSET,
             MAINPROCESS,
             MAINCAM,
-            LEFTCAM,
-            RIGHTCAM,
             GROUNDCAM,
             MAINDETECTOR,
-            LEFTDETECTOR,
-            RIGHTDETECTOR,
+            GROUNDDETECTOR,
             STATEMACHINE,
             ROVECOMMUDP,
             ROVECOMMTCP
@@ -436,7 +433,7 @@ namespace manifest
      * @brief Camera1 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace Camera1
     {
@@ -445,16 +442,15 @@ namespace manifest
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"CHANGECAMERAS", ManifestEntry{12000, 2, DataTypes::UINT8_T}},
-            {"TAKEPICTURE", ManifestEntry{12001, 2, DataTypes::UINT8_T}},
-            {"TOGGLESTREAM1", ManifestEntry{12002, 2, DataTypes::UINT8_T}},
+            {"TAKEPICTURE", ManifestEntry{12000, 2, DataTypes::UINT8_T}},
+            {"TOGGLESTREAM", ManifestEntry{12001, 2, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
             {"AVAILABLECAMERAS", ManifestEntry{12100, 1, DataTypes::UINT8_T}},
-            {"STREAMINGCAMERAS", ManifestEntry{12101, 4, DataTypes::UINT8_T}},
-            {"PICTURETAKEN1", ManifestEntry{12102, 1, DataTypes::UINT8_T}},
+            {"STREAMINGCAMERAS", ManifestEntry{12101, 1, DataTypes::UINT8_T}},
+            {"PICTURETAKEN", ManifestEntry{12102, 1, DataTypes::UINT8_T}},
         };
 
         // Error
@@ -467,7 +463,7 @@ namespace manifest
      * @brief Camera2 Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace Camera2
     {
@@ -476,13 +472,15 @@ namespace manifest
 
         // Commands
         const std::map<std::string, ManifestEntry> COMMANDS = {
-            {"TAKEPICTURE", ManifestEntry{13001, 2, DataTypes::UINT8_T}},
-            {"TOGGLESTREAM2", ManifestEntry{13002, 2, DataTypes::UINT8_T}},
+            {"TAKEPICTURE", ManifestEntry{13000, 2, DataTypes::UINT8_T}},
+            {"TOGGLESTREAM", ManifestEntry{13001, 2, DataTypes::UINT8_T}},
         };
 
         // Telemetry
         const std::map<std::string, ManifestEntry> TELEMETRY = {
-            {"PICTURETAKEN2", ManifestEntry{13100, 1, DataTypes::UINT8_T}},
+            {"AVAILABLECAMERAS", ManifestEntry{13100, 1, DataTypes::UINT8_T}},
+            {"STREAMINGCAMERAS", ManifestEntry{13101, 1, DataTypes::UINT8_T}},
+            {"PICTURETAKEN", ManifestEntry{13102, 1, DataTypes::UINT8_T}},
         };
 
         // Error
@@ -493,7 +491,7 @@ namespace manifest
      * @brief CameraServer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace CameraServer
     {
@@ -530,7 +528,7 @@ namespace manifest
      * @brief IRSpectrometer Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace IRSpectrometer
     {
@@ -549,7 +547,7 @@ namespace manifest
      * @brief Raman Board IP Address, Commands, Telemetry, and Error Packet 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace Raman
     {
@@ -566,6 +564,7 @@ namespace manifest
             {"WATCHDOGOVERRIDE", ManifestEntry{16005, 1, DataTypes::UINT8_T}},
             {"LASER", ManifestEntry{16006, 1, DataTypes::UINT8_T}},
             {"REQUESTRAMANREADING", ManifestEntry{16007, 1, DataTypes::UINT32_T}},
+            {"RAMANGIMBALINCREMENT", ManifestEntry{16008, 2, DataTypes::INT16_T}},
         };
 
         // Telemetry
@@ -588,7 +587,7 @@ namespace manifest
      * @brief RoveSoSimulator Board IP Address, Commands, Telemetry, and Error 
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace RoveSoSimulator
     {
@@ -610,7 +609,7 @@ namespace manifest
      * @brief RoveComm General Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace General
     {
@@ -625,7 +624,7 @@ namespace manifest
      * @brief RoveComm System Information
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace System
     {
@@ -641,7 +640,7 @@ namespace manifest
      * @brief RoveComm Helper Functions
      *
      * @author Missouri S&T - Mars Rover Design Team
-     * @date 2025-04-07
+     * @date 2025-04-21
      ******************************************************************************/
     namespace Helpers
     {


### PR DESCRIPTION
This should fix the manifest action not kicking off when we update the manifest submodule. I think what was happening is that, since the manifest.json was moved to a different repo, the action was failing to pick up changes to the file in the submodule. This fix will change it to monitoring the entire submodule reference, so any changes to the manifest repo should kick off this action now.