### PR TITLE
Removed fortran from the dockerfiles

### DIFF
--- a/.devcontainer/Dockerfile_Jammy
+++ b/.devcontainer/Dockerfile_Jammy
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     build-essential gdb wget less udev zstd sudo libgomp1 libswscale-dev \
     cmake git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev \
     libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev tzdata curl \
-    yasm libatlas-base-dev gfortran libpq-dev libavutil-dev libpostproc-dev \
+    yasm libatlas-base-dev libpq-dev libavutil-dev libpostproc-dev \
     libxine2-dev libglew-dev libtiff5-dev zlib1g-dev cowsay locales \
     libeigen3-dev python3-dev python3-pip python3-numpy libx11-dev \
     libboost-all-dev valgrind doxygen graphviz htop nano fortune fortunes mingw-w64

--- a/.devcontainer/Dockerfile_JetPack
+++ b/.devcontainer/Dockerfile_JetPack
@@ -26,7 +26,7 @@ RUN echo "# R${L4T_MAJOR} (release), REVISION: ${L4T_MINOR}.${L4T_PATCH}" > /etc
 
 # Install Required Ubuntu Packages
 RUN apt-get update && apt-get install --no-install-recommends -y \
-    build-essential gfortran cmake git gdb file tar libatlas-base-dev apt-transport-https  \
+    build-essential cmake git gdb file tar libatlas-base-dev apt-transport-https  \
     libavcodec-dev libavformat-dev libswresample-dev libcanberra-gtk3-module zstd wget less \
     libdc1394-dev libeigen3-dev libglew-dev libgstreamer-plugins-base1.0-dev udev curl \
     libgstreamer-plugins-good1.0-dev libgstreamer1.0-dev libgtk-3-dev libjpeg-dev sudo \


### PR DESCRIPTION
# Description
A removal of gfortran from the dockerfile as it is not used anywhere in the codebase and is thus not needed.

# Changes Made
Removed gfortran from the jammy and jetPack dockerfiles APT installed packages.

# Additional Context
Adam will hate this and say this PR is blasphemy.